### PR TITLE
Update hamburger link markup to trigger mobile navigation.

### DIFF
--- a/django/santropolFeast/santropolFeast/templates/base.html
+++ b/django/santropolFeast/santropolFeast/templates/base.html
@@ -29,7 +29,7 @@
                 <!-- Responsive top menu -->
                 <div class="ui fixed inverted main menu">
                     <div class="ui container">
-                        <a class="launch icon item sidebar-toggle">
+                        <a class="launch icon item sidebar-toggle ui open-menu">
                             <i class="sidebar icon"></i>
                         </a>
                     </div>


### PR DESCRIPTION
*Fixes #327 *

### Changes proposed in this pull request:

* Add "ui" and "open-menu" class to hamburger menu link in order to open navigation on screen with resolution smaller than 1200px.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### Deployment notes and migration

- [ ] Migration needed

Fill me in ...

@savoirfairelinux/mll