### PR TITLE
Update Django to version 1.10 and use version 2 of docker-compose con…

### DIFF
--- a/django/santropolFeast/order/factories.py
+++ b/django/santropolFeast/order/factories.py
@@ -57,9 +57,8 @@ class OrderItemFactory(factory.DjangoModelFactory):
 
     price = fake.random_int(min=0, max=50)
 
-    billable_flag = fake.random_sample(
-        elements=(True, False),
-        length=None
+    billable_flag = factory.LazyAttribute(
+        lambda x: random.choice([True, False])
     )
 
     size = factory.LazyAttribute(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,16 @@
-db:
-  image: mariadb
-
-
-  environment:
-    MYSQL_ROOT_PASSWORD: 123456
-    MYSQL_DATABASE: feast
-
-web:
-  build: .
-  command: python3 django/santropolFeast/manage.py runserver 0.0.0.0:8000
-  volumes:
-    - .:/code
-  ports:
-    - "8000:8000"
-  links:
-    - db
+version: '2'
+services:
+  db:
+    image: mariadb
+    environment:
+      MYSQL_ROOT_PASSWORD: 123456
+      MYSQL_DATABASE: feast
+  web:
+    build: .
+    command: python django/santropolFeast/manage.py runserver 0.0.0.0:8000
+    volumes:
+      - .:/code
+    ports:
+      - "8000:8000"
+    depends_on:
+      - db

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-django==1.9.8
+django==1.10
 mysqlclient==1.3.7
 factory_boy==2.7.0
 django-formtools==1.0


### PR DESCRIPTION
*Fixes #348  .*

### Changes proposed in this pull request:

* Update Django to version 1.10
* Use version 2 of docker-compose file
* Fix small error to make the order factories to make it work with Django-1.10

### Status

- [X] READY


### Deployment notes and migration

- [X] Rebuild of docker containers and images needed.
