### PR TITLE
fix346 add client and meal relationships in admin

### DIFF
--- a/django/santropolFeast/meal/admin.py
+++ b/django/santropolFeast/meal/admin.py
@@ -1,10 +1,74 @@
+from django.db.models.functions import Lower
 from django.contrib import admin
 from meal.models import Component, Restricted_item
 from meal.models import Ingredient, Component_ingredient
 from meal.models import Incompatibility, Menu, Menu_component
 
-admin.site.register(Component)
-admin.site.register(Restricted_item)
+
+# Component model and its relationships
+#
+class ComponentIngredientInline(admin.TabularInline):
+    model = Component_ingredient
+    fields = ('ingredient', 'ingredient_group',)
+    readonly_fields = ('ingredient_group',)
+    extra = 1
+
+    def get_queryset(self, request):
+        return (Component_ingredient.objects.
+                filter(date=None).
+                order_by(Lower('ingredient__ingredient_group'),
+                         Lower('ingredient__name')))
+
+    def ingredient_group(self, instance):
+        return instance.ingredient.ingredient_group
+
+
+class ComponentAdmin(admin.ModelAdmin):
+    fields = (
+        'name',
+        'description',
+        'component_group',
+    )
+
+    inlines = (
+        ComponentIngredientInline,
+    )
+
+admin.site.register(Component, ComponentAdmin)
+# END Component
+
+
+# Restricted_item model and its relationships
+#
+class IncompatibilityInline(admin.TabularInline):
+    model = Incompatibility
+    fields = ('ingredient', 'ingredient_group',)
+    readonly_fields = ('ingredient_group',)
+    extra = 1
+
+    def get_queryset(self, request):
+        return (Incompatibility.objects.
+                order_by(Lower('ingredient__ingredient_group'),
+                         Lower('ingredient__name')))
+
+    def ingredient_group(self, instance):
+        return instance.ingredient.ingredient_group
+
+
+class RestrictedItemAdmin(admin.ModelAdmin):
+    fields = (
+        'name',
+        'description',
+        'restricted_item_group',
+    )
+
+    inlines = (
+        IncompatibilityInline,
+    )
+
+admin.site.register(Restricted_item, RestrictedItemAdmin)
+# END Restricted_item
+
 admin.site.register(Ingredient)
 admin.site.register(Component_ingredient)
 admin.site.register(Incompatibility)

--- a/django/santropolFeast/member/admin.py
+++ b/django/santropolFeast/member/admin.py
@@ -4,8 +4,88 @@ from member.models import (Member, Client, Contact, Address,
                            Client_avoid_ingredient, Option,
                            Client_option, Restriction)
 
+
 admin.site.register(Member)
-admin.site.register(Client)
+
+
+# Client model and its relationships
+#
+class RestrictionInline(admin.TabularInline):
+    model = Restriction
+    extra = 1
+
+
+class ClientAvoidIngredientInline(admin.TabularInline):
+    model = Client_avoid_ingredient
+    extra = 1
+
+
+class ClientAvoidComponentInline(admin.TabularInline):
+    model = Client_avoid_component
+    extra = 1
+
+
+class ReferencingInline(admin.StackedInline):
+    model = Referencing
+    fields = ('referent', 'date', 'referral_reason', 'work_information')
+    extra = 0
+
+
+class ClientOptionInline(admin.TabularInline):
+    fields = ('option', 'option_group', 'value',)
+    readonly_fields = ('option_group',)
+    model = Client_option
+    extra = 1
+
+    def option_group(self, instance):
+        return instance.option.option_group
+
+
+class ClientAdmin(admin.ModelAdmin):
+    fields = (
+        'member',
+        'address_details',
+        'gender',
+        'language',
+        'delivery_type',
+        'birthdate',
+        'billing_member',
+        'billing_payment_type',
+        'rate_type',
+        'emergency_contact',
+        'emergency_contact_relationship',
+        'status',
+        'alert',
+        'route',
+        'meal_default_week',
+        'delivery_note',
+    )
+    readonly_fields = ('address_details',)
+
+    inlines = (
+        ClientOptionInline,
+        ClientAvoidIngredientInline,
+        ClientAvoidComponentInline,
+        RestrictionInline,
+        ReferencingInline,
+    )
+
+    def address_details(self, instance):
+        address = instance.member.address
+        return (
+            '{} '.format(address.number) +
+            '{}, '.format(address.street) +
+            ('Apt {}, '.format(address.apartment) if address.apartment
+             else '') +
+            ('{} floor, '.format(address.floor) if address.floor
+             else '') +
+            '{} '.format(address.city) +
+            '{}'.format(address.postal_code)
+        )
+
+admin.site.register(Client, ClientAdmin)
+# END Client
+
 admin.site.register(Route)
 admin.site.register(Contact)
 admin.site.register(Address)


### PR DESCRIPTION
_Fixes #346 ._
### Changes proposed in this pull request:
- Admin / Meal / Component : recipe_ingredients
- Admin / Meal / Restricted_item : incompatible_ingredients
- Admin / Member / Client : address, client_options, client_avoid_ingredients, client_avoid_components, restricted_items, referents
- tests
### Status
- [ ] READY
- [X] HOLD until I fix issue #357 
- [ ] WIP (Work-In-Progress)
### Deployment notes and migration
- [ ] Migration needed

@savoirfairelinux/mll
