### PR TITLE
In delivery map clean waypoints popup - display address and name only

### DIFF
--- a/django/santropolFeast/delivery/templates/routes.html
+++ b/django/santropolFeast/delivery/templates/routes.html
@@ -106,12 +106,11 @@
         // Ajax call to get waypoint according route
         $.get( "../getDailyOrders/?route="+routeId, function(data ) {
 
-            var deliveryPoints = L.Routing.Waypoint.extend({ member:"", address:"", meal:"", notes:"", allergies:"" });
+            var deliveryPoints = L.Routing.Waypoint.extend({ member:"", address:""});
             // create an array of waypoint from ajax call
             for(var i in data.waypoints)
             {
                  waypoints.push(new deliveryPoints(L.latLng(data.waypoints[i].latitude, data.waypoints[i].longitude)) );
-                 waypoints[i].options.meal = data.waypoints[i].meal;
                  waypoints[i].options.address = data.waypoints[i].address;
                  waypoints[i].options.member = data.waypoints[i].member;
                  waypoints[i].options.id = data.waypoints[i].id;
@@ -202,8 +201,6 @@
                            var info = "<div class='ui list'>"
                                           +"<div class='item'><i class='user icon'></i>" + wp.options.member + "</div>"
                                           +"<div class='item'><i class='home icon'></i>" + wp.options.address + "</div>"
-                                          +"<div class='item'><i class='food icon'></i>" + wp.options.meal + "</div>"
-                                          +"<div class='item'><i class='warning circle icon'></i>" + wp.options.meal + "</div>"
                                           +"</div>"
 
                            marker.bindPopup(info).openPopup();

--- a/django/santropolFeast/delivery/views.py
+++ b/django/santropolFeast/delivery/views.py
@@ -373,8 +373,8 @@ def dailyOrders(request):
                     'member': "{} {}".format(
                         order.client.member.firstname,
                         order.client.member.lastname),
-                    'address': order.client.member.address.street,
-                    'meal': 'meat'}
+                    'address': order.client.member.address.street
+                    }
                 data.append(waypoint)
 
     waypoints = {'waypoints': data}


### PR DESCRIPTION
*Fixes # .323

### Changes proposed in this pull request:

* remove extra info in waypoints popup - keep only name and address

### Status

- [X ] READY
- [ ] HOLD
- [] WIP (Work-In-Progress)

### Deployment notes and migration

- [ ] Migration needed

Fill me in ...

@savoirfairelinux/mll

