### PR TITLE
Fixes CSV and PDF export links within order list page

### DIFF
--- a/src/sous-chef/templates/system/_button_export.html
+++ b/src/sous-chef/templates/system/_button_export.html
@@ -4,8 +4,8 @@
         <i class="dropdown icon"></i>
                 <div class="menu transition hidden">
                     <div class="header">Format</div>
-                    <div class="item"><a href="{{request.get_full_path}}&format=csv">CSV</a></div>
-                    <div class="item"><a href="{{request.get_full_path}}&format=pdf">PDF</a></div>
+                    <div class="item"><a href="{{request.path}}?{{request.META.QUERY_STRING}}&format=csv">CSV</a></div>
+                    <div class="item"><a href="{{request.path}}?{{request.META.QUERY_STRING}}&format=pdf">PDF</a></div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
*Fixes #373 by fixing the export links*

It used to only work if you had a query string (i.e. had filtered the order list). Will now work without an existing query string as well (URL becomes "/order/list/?&format=csv", which works).

### Changes proposed in this pull request:

* Change the way the URL is built in the template, to preserve the query string and append the "format" param.

### Status

- [X ] READY

### Deployment notes and migration

- [ ] Migration needed