### PR TITLE
Display 'Active','Pending',etc instead of 'A','P' in client_export.csv

### DIFF
--- a/src/member/views.py
+++ b/src/member/views.py
@@ -667,7 +667,7 @@ def ExportCSV(self, queryset):
             obj.id,
             obj.member.firstname,
             obj.member.lastname,
-            obj.status,
+            obj.get_status_display(),
             obj.alert,
             obj.gender,
             obj.birthdate,


### PR DESCRIPTION
*Fixes #375*

### Changes proposed in this pull request:
Changes the ClientExportCSV function to show the human readable client status instead of the 1 character version stored in the database.

This means that the client_export.csv file, under 'Client Status' will have eg, 'Active', or 'Pending' instead of 'A' or 'P'.

### Status

- [X] READY

### Deployment notes and migration

- [X] No migration needed
