### PR TITLE
Change property used to build the URL to member's information page

### DIFF
--- a/src/note/templates/notes_list.html
+++ b/src/note/templates/notes_list.html
@@ -63,7 +63,7 @@
         </div>
         <i class="{% if note.priority == 'urgent' %} warning sign {% else %} info {% endif %} middle aligned icon"></i>
         <div class="content">
-            <a class="header" href="{% url 'member:view' pk=note.client.id %}">{{note.client}}</a>
+            <a class="header" href="{% url 'member:client_information' pk=note.client.id %}">{{note.client}}</a>
             <div class="description">
                 {{ note.note }}
             </div>


### PR DESCRIPTION
*Fixes #387 *

### Changes proposed in this pull request:

* Use proper member's property to build the URL to get to the information page

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)