### PR TITLE
Pagination for Orders list. (Issue #377)

### DIFF
--- a/src/order/templates/list.html
+++ b/src/order/templates/list.html
@@ -91,6 +91,28 @@
   </tfoot>
 </table>
 
+{% if is_paginated %}
+
+<div class="ui pagination menu" style="margin: 2em auto; width=100%;";>
+    {% if page_obj.has_previous %}
+    <a class="icon item"
+       href="{{ request.path }}{{ get }}display={{ display }}&page={{ page_obj.previous_page_number }}">
+        <i class="left arrow icon"></i>
+    </a>
+    {% endif %}
+    <a class="active item">
+        {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}
+    </a>
+    {% if page_obj.has_next %}
+    <a class="icon item"
+       href="{{ request.path }}{{ get }}display={{ display }}&page={{ page_obj.next_page_number }}">
+        <i class="right arrow icon"></i>
+    </a>
+    {% endif %}
+</div>
+{% endif %}
+
+
 {% else %}
     <div class="ui row"><p>Sorry, no result found.</p></div>
 {% endif %}

--- a/src/order/views.py
+++ b/src/order/views.py
@@ -15,6 +15,7 @@ class OrderList(generic.ListView):
     model = Order
     template_name = 'list.html'
     context_object_name = 'orders'
+    paginate_by = 20
 
     @method_decorator(login_required)
     def dispatch(self, *args, **kwargs):
@@ -35,6 +36,8 @@ class OrderList(generic.ListView):
         text = ''
         count = 0
         for getVariable in self.request.GET:
+            if getVariable == "display" or getVariable == "page":
+                continue
             for getValue in self.request.GET.getlist(getVariable):
                 if count == 0:
                     text += "?" + getVariable + "=" + getValue
@@ -42,6 +45,7 @@ class OrderList(generic.ListView):
                     text += "&" + getVariable + "=" + getValue
                 count += 1
 
+        text = text + "?" if count == 0 else text + "&"
         context['get'] = text
 
         return context

--- a/src/sous-chef/templates/system/menu.html
+++ b/src/sous-chef/templates/system/menu.html
@@ -24,7 +24,7 @@
 
     <div class="item">
         <form action="{% url 'member:list' %}" method="get">
-            <div class="ui icon transparent inverted input">
+            <div class="ui icon transparent inverted input" style="display: block;">
                 <input type="text" name="name" placeholder="Search client...">
                 <i class="search icon"></i>
             </div>


### PR DESCRIPTION
*Fixes #377.*

### Changes proposed in this pull request:

* Added pagination to the Orders list

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### Deployment notes and migration

- [ ] Migration needed

Fill me in ...

- Pagination is hard-coded to 20.
- BUG: Deleting an order on page >1 brings you back to page 1 after the delete operation is complete. (This is might get really frustrating if the user needs to perform a batch operation, and needs to navigate back to the relevant page after each deletion.)

@savoirfairelinux/mll

