### PR TITLE
Fix alignment of search icon in sidebar (Issue #371).

### DIFF
--- a/src/sous-chef/templates/system/menu.html
+++ b/src/sous-chef/templates/system/menu.html
@@ -24,7 +24,7 @@
 
     <div class="item">
         <form action="{% url 'member:list' %}" method="get">
-            <div class="ui icon transparent inverted input">
+            <div class="ui icon transparent inverted input" style="display: block;">
                 <input type="text" name="name" placeholder="Search client...">
                 <i class="search icon"></i>
             </div>


### PR DESCRIPTION
*Fixes #371*

### Changes proposed in this pull request:

* Change a CSS rule to allow proper alignment of search icon in sidebar.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### Deployment notes and migration

- [ ] Migration needed

Fill me in ...

- The problem was resulting from the `display: inline-flex-box` directive applied to the enclosing `<div>` (defined in semantic-ui.css). I changed this to `display: block` for this element only, allowing the icon's absolute positioning to be applied as expected.

@savoirfairelinux/mll

