### PR TITLE
Modify the Component admin page so that component ingredients are inl…

### DIFF
--- a/src/meal/admin.py
+++ b/src/meal/admin.py
@@ -7,14 +7,17 @@ from meal.models import Incompatibility, Menu, Menu_component
 class ComponentsInline(admin.TabularInline):
     model = Menu.components.through
 
+
 class ComponentIngredientInline(admin.TabularInline):
     model = Component_ingredient
+
 
 class MenuAdmin(admin.ModelAdmin):
     """Allows accessing menu components within the Menu admin."""
     inlines = [
         ComponentsInline
     ]
+
 
 class ComponentAdmin(admin.ModelAdmin):
     """Allows accessing ingredients within the Component admin."""

--- a/src/meal/admin.py
+++ b/src/meal/admin.py
@@ -7,17 +7,24 @@ from meal.models import Incompatibility, Menu, Menu_component
 class ComponentsInline(admin.TabularInline):
     model = Menu.components.through
 
+class ComponentIngredientInline(admin.TabularInline):
+    model = Component_ingredient
 
 class MenuAdmin(admin.ModelAdmin):
-
+    """Allows accessing menu components within the Menu admin."""
     inlines = [
         ComponentsInline
     ]
 
+class ComponentAdmin(admin.ModelAdmin):
+    """Allows accessing ingredients within the Component admin."""
+    inlines = [
+        ComponentIngredientInline
+    ]
 
-admin.site.register(Component)
+
+admin.site.register(Component, ComponentAdmin)
 admin.site.register(Restricted_item)
 admin.site.register(Ingredient)
-admin.site.register(Component_ingredient)
 admin.site.register(Incompatibility)
 admin.site.register(Menu, MenuAdmin)


### PR DESCRIPTION
*Improves the Component admin interface by inlining Component ingredients*

### Changes proposed in this pull request:

* Inline the Component_ingredient in the Component admin (allows to see, modify, add Component ingredients). See screenshot.
* Remove Component_ingredients from being a standalone item in the admin (now entirely accessible through Component admin). Note: There is still "Ingredients" as standalone in the admin. 

### Status

- [X] READY

### Deployment notes and migration

No special deployment step.

<img width="1123" alt="screen shot 2016-08-26 at 10 33 12 am" src="https://cloud.githubusercontent.com/assets/499162/18009356/d696355e-6b79-11e6-99b8-9cbb7f69d19f.png">