### PR TITLE
Supply proper redirect ('next') value when deleting an order

### DIFF
--- a/src/order/templates/order_confirm_delete.html
+++ b/src/order/templates/order_confirm_delete.html
@@ -9,7 +9,7 @@
       <p>{% trans 'This order will be deleted and all the info will be lost, are you sure?' %}</p>
   </div>
   <div class="actions">
-    <form action="{% url 'order:delete' pk=order.id %}" method="POST" id="order-{{order.id}}-delete-form">{% csrf_token %}
+    <form action="{% url 'order:delete' pk=order.id %}?next={% url 'order:list' %}%3F{{request.META.QUERY_STRING|urlencode}}" method="POST" id="order-{{order.id}}-delete-form">{% csrf_token %}
        <div class="ui red cancel button"> <i class="remove icon"></i> No </div>
        <button class="ui green button" type="submit"> <i class="checkmark icon"></i> Yes </button>
    </form>

--- a/src/order/tests.py
+++ b/src/order/tests.py
@@ -1,4 +1,5 @@
 import random
+import urllib.parse
 from datetime import date
 
 from django.test import TestCase
@@ -453,8 +454,13 @@ class DeleteOrderTestCase(OrderFormTestCase):
         self.assertContains(response, 'Delete Order #{}'.format(self.order.id))
 
     def test_delete_order(self):
+        # The template will POST with a 'next' parameter, which is the URL to
+        # follow on success.
+        next_value = '?name=&status=O&delivery_date='
         response = self.client.post(
-            reverse('order:delete', args=(self.order.id,)),
+            (reverse('order:delete', args=(self.order.id,)) + '?next=' +
+                reverse('order:list') + urllib.parse.quote_plus(next_value)),
             follow=True
         )
-        self.assertRedirects(response, reverse('order:list'), status_code=302)
+        self.assertRedirects(response, reverse('order:list') + next_value,
+                             status_code=302)

--- a/src/order/views.py
+++ b/src/order/views.py
@@ -121,7 +121,10 @@ class UpdateOrderStatus(AjaxableResponseMixin, generic.UpdateView):
 class DeleteOrder(generic.DeleteView):
     model = Order
     template_name = 'order_confirm_delete.html'
-    success_url = reverse_lazy('order:list')
+
+    def get_success_url(self):
+        # 'next' parameter should always be included in POST'ed URL.
+        return self.request.GET['next']
 
 
 def ExportCSV(request, queryset):


### PR DESCRIPTION
*Fixes #411 by providing a 'next' url param.*

### Changes proposed in this pull request:

* The template for delete confirmation will now POST to a URL and provide its next destination, which is the order list with the same current set of URL params.
  * This way, when deleting an order, the next page will contain the same search filters. 

### Status

- [X] READY

### Deployment notes and migration

Fill me in ...

In the previous situation, at the point where the deletion was confirmed in DeleteOrder, it was difficult to get back to the previous set of URL parameters. A common pattern in Django is to provide a 'next' parameter, which we use here to follow the URL to the filtered order list.

@savoirfairelinux/mll

