### PR TITLE
Do not show link to referent if none are available

### DIFF
--- a/src/member/forms.py
+++ b/src/member/forms.py
@@ -375,7 +375,7 @@ class ClientScheduledStatusForm(forms.ModelForm):
 
 def load_initial_data(client):
     """
-    Load initial for the given step and client.
+    Load initial for the given client.
     """
     initial = {
         'firstname': client.member.firstname,
@@ -394,9 +394,18 @@ def load_initial_data(client):
         'latitude': client.member.address.latitude,
         'longitude': client.member.address.longitude,
         'distance': client.member.address.distance,
-        'work_information': client.client_referent.get().work_information,
-        'referral_reason': client.client_referent.get().referral_reason,
-        'date': client.client_referent.get().date,
+        'work_information':
+            client.client_referent.get().work_information
+            if client.client_referent.count()
+            else '',
+        'referral_reason':
+            client.client_referent.get().referral_reason
+            if client.client_referent.count()
+            else '',
+        'date':
+            client.client_referent.get().date
+            if client.client_referent.count()
+            else '',
         'member': client.id,
         'same_as_client': True,
         'facturation': '',

--- a/src/member/templates/client/partials/menu.html
+++ b/src/member/templates/client/partials/menu.html
@@ -6,7 +6,7 @@
       <a class="{% if active_tab == 'information' %}active{% endif %} item" href="{% url 'member:client_information' pk=client.id %}"><i class="user icon"></i>{% trans 'Personal' %}</a>
       {% if client.client_referent.all.count %}
       <a class="{% if active_tab == 'referent' %}active{% endif %} item" href="{% url 'member:client_referent' pk=client.id %}"><i class="treatment icon"></i>{% trans 'Referent' %}</a>
-      {% else %}<span class="item">{% trans 'No referent available' %}</span>{% endif %}
+      {% else %}<em><a class="item" alt="{% trans 'Add a referent' %} "href="{% url 'member:member_update_referent_information' client_id=client.id %}"><i class="warning sign orange icon"></i>{% trans 'No referent available' %}</a></em>{% endif %}
       <a class="{% if active_tab == 'billing' %}active{% endif %} item" href="{% url 'member:client_payment' pk=client.id %}"><i class="payment icon"></i>{% trans 'Billing' %}</a>
       <a class="{% if active_tab == 'status' %}active{% endif %} item" href="{% url 'member:client_status' pk=client.id %}"><i class="history icon"></i>{% trans 'Status' %}</a>
     </div>

--- a/src/member/templates/client/partials/menu.html
+++ b/src/member/templates/client/partials/menu.html
@@ -1,25 +1,26 @@
+{% load i18n %}
 <div class="ui vertical menu">
   <div class="item">
-    Information
+    {% trans 'Information' %}
     <div class="menu">
-      <a class="{% if active_tab == 'information' %}active{% endif %} item" href="{% url 'member:client_information' pk=client.id %}"><i class="user icon"></i>Personal</a>
+      <a class="{% if active_tab == 'information' %}active{% endif %} item" href="{% url 'member:client_information' pk=client.id %}"><i class="user icon"></i>{% trans 'Personal' %}</a>
       {% if client.client_referent.all.count %}
-      <a class="{% if active_tab == 'referent' %}active{% endif %} item" href="{% url 'member:client_referent' pk=client.id %}"><i class="treatment icon"></i>Referent</a>
-      {% else %}<span class="item">No referent available</span>{% endif %}
-      <a class="{% if active_tab == 'billing' %}active{% endif %} item" href="{% url 'member:client_payment' pk=client.id %}"><i class="payment icon"></i>Billing</a>
-      <a class="{% if active_tab == 'status' %}active{% endif %} item" href="{% url 'member:client_status' pk=client.id %}"><i class="history icon"></i>Status</a>
+      <a class="{% if active_tab == 'referent' %}active{% endif %} item" href="{% url 'member:client_referent' pk=client.id %}"><i class="treatment icon"></i>{% trans 'Referent' %}</a>
+      {% else %}<span class="item">{% trans 'No referent available' %}</span>{% endif %}
+      <a class="{% if active_tab == 'billing' %}active{% endif %} item" href="{% url 'member:client_payment' pk=client.id %}"><i class="payment icon"></i>{% trans 'Billing' %}</a>
+      <a class="{% if active_tab == 'status' %}active{% endif %} item" href="{% url 'member:client_status' pk=client.id %}"><i class="history icon"></i>{% trans 'Status' %}</a>
     </div>
   </div>
   <a class="{% if active_tab == 'prefs' %}active{% endif %} item" href="{% url 'member:client_allergies' pk=client.id %}">
-    <i class="food icon"></i>Preferences
+    <i class="food icon"></i>{% trans 'Preferences' %}
   </a>
   <a class="{% if active_tab == 'notes' %}active{% endif %} item" href="{% url 'member:client_notes' pk=client.id %}">
     <div class="ui teal label">{{ client.notes.count }}</div>
-    Notes
+    {% trans 'Notes' %}
   </a>
   <a class="{% if active_tab == 'orders' %}active{% endif %} item" href="{% url 'member:list_orders' pk=client.id %}">
       <div class="ui teal label">{{ client.orders.count }}</div>
-    Orders
+    {% trans 'Orders' %}
   </a>
 
 </div>

--- a/src/member/templates/client/partials/menu.html
+++ b/src/member/templates/client/partials/menu.html
@@ -3,7 +3,9 @@
     Information
     <div class="menu">
       <a class="{% if active_tab == 'information' %}active{% endif %} item" href="{% url 'member:client_information' pk=client.id %}"><i class="user icon"></i>Personal</a>
+      {% if client.client_referent.all.count %}
       <a class="{% if active_tab == 'referent' %}active{% endif %} item" href="{% url 'member:client_referent' pk=client.id %}"><i class="treatment icon"></i>Referent</a>
+      {% else %}<span class="item">No referent available</span>{% endif %}
       <a class="{% if active_tab == 'billing' %}active{% endif %} item" href="{% url 'member:client_payment' pk=client.id %}"><i class="payment icon"></i>Billing</a>
       <a class="{% if active_tab == 'status' %}active{% endif %} item" href="{% url 'member:client_status' pk=client.id %}"><i class="history icon"></i>Status</a>
     </div>

--- a/src/member/templates/client/view/information.html
+++ b/src/member/templates/client/view/information.html
@@ -15,7 +15,7 @@
     <h2 class="ui header">
         <div class="content">
             {% trans 'Basic information' %}
-            <div class="sub header">Contact information of the referent person.<a  href="{% url 'admin:member_client_change' client.id %}">
+            <div class="sub header">Contact information of the client.<a  href="{% url 'admin:member_client_change' client.id %}">
                 <i class="write grey icon"></i>
             </a></div>
         </div>


### PR DESCRIPTION
*Fixes #380 by not including a referent link if none is available.*

### Changes proposed in this pull request:

* If no referent is available, do not show a link to the referent view.
  * Instead, show "No referent available".
* Added translation tags.
* Changed a string for the client/view/information.html which was a result of bad copy/paste.

### Status

- [X] READY

### Deployment notes and migration

TEST: Visual testing.

<img width="215" alt="screen shot 2016-08-26 at 5 58 08 pm" src="https://cloud.githubusercontent.com/assets/499162/18021611/c325e694-6bb6-11e6-9519-62ff9eded542.png">

Fill me in ...

Testing for a referent in the template before displaying the link to it.

@savoirfairelinux/mll

