### PR TITLE
Add trans tags in the 'client' app

### DIFF
--- a/src/member/templates/client/create/form.html
+++ b/src/member/templates/client/create/form.html
@@ -15,7 +15,7 @@
 {% endblock %}
 
 {% block title %}
-    {% if edit == True %}Edit existing client{% else %}Create a new client{% endif %}
+    {% if edit == True %}{% trans 'Edit existing client' %}{% else %}{% trans 'Create a new client ' %}{% endif %}
 {% endblock %}
 
 {% block message %}
@@ -23,9 +23,9 @@
     <div class="ui warning small message">
         <div class="header">Notice</div>
         {% if not edit %}
-        <p>No information will be saved until all the steps are completed.</p>
+        <p>{% trans 'No information will be saved until all the steps are completed.' %}</p>
         {% else %}
-        <p>Save as soon as you're ready.</p>
+        <p>{% trans 'Save as soon as you\'re ready.' %}</p>
         {% endif %}
     </div>
 </div>
@@ -35,7 +35,7 @@
 
 <div class="ui secondary pointing fluid menu">
     <h1 class="ui header">
-        {% if edit == True %}Edit Client{% else %}New Client{% endif %}
+        {% if edit == True %}{% trans 'Edit Client' %}{% else %}{% trans 'New Client' %}{% endif %}
     </h1>
 </div>
 
@@ -66,14 +66,14 @@
 
         {% if wizard.steps.prev and not edit %}
         <button class="ui left floated button" name="wizard_goto_step" type="submit" value="{{wizard.steps.prev}}">
-            {% trans "Back"%}
+            {% trans 'Back' %}
         </button>
         {% endif %}
 
         {% if wizard.steps.step1 == 6 %}
-            <input class="big ui right floated yellow button" type="submit" value="Save"/>
+            <input class="big ui right floated yellow button" type="submit" value="{% trans 'Save' %}"/>
         {% else %}
-            <button  class="big ui yellow right floated button" name="wizard_goto_step" type="submit">Next</button>
+            <button  class="big ui yellow right floated button" name="wizard_goto_step" type="submit">{% trans 'Next' %}</button>
         {% endif %}
 
     </form>

--- a/src/member/templates/client/partials/birthdays.html
+++ b/src/member/templates/client/partials/birthdays.html
@@ -1,5 +1,6 @@
+{% load i18n %}
 <div class="ui segment">
-  <h3 class="ui blue header">Happy Birthday</h3>
+  <h3 class="ui blue header">{% trans 'Happy Birthday' %}</h3>
   </div>
   <div class="ui segment">
       <table class="ui very basic table">

--- a/src/member/templates/client/partials/forms/address_information.html
+++ b/src/member/templates/client/partials/forms/address_information.html
@@ -1,3 +1,4 @@
+{% load i18n %}
 <h4 class="ui dividing header">{{ _('Address information') }}</h4>
 
 <div class="field">
@@ -27,7 +28,7 @@
 
 <div class="field">
     <button id="geocodeBtn" type="button" class="ui yellow button">
-      <i class="marker icon"></i>Geolocate
+      <i class="marker icon"></i>{% trans 'Geolocate' %}
     </button>
     <i class="help-text question grey icon link" data-content="{{ form.status.help_text }}"></i>
 

--- a/src/member/templates/client/partials/forms/basic_information.html
+++ b/src/member/templates/client/partials/forms/basic_information.html
@@ -1,3 +1,4 @@
+{% load i18n %}
 <h4 class="ui dividing header">{{ _('Identity') }}</h4>
 <div class="field">
     <label>{{ _('Name') }}</label>
@@ -51,7 +52,7 @@
 <h4 class="ui dividing header">{{ _('Alert') }}</h4>
 <div class="field {% if form.alert.errors %} error {% endif %}">
     <div class="ui message attached">
-        <p>This message will be hightlighted on the client record.</p>
+        <p>{% trans 'This message will be hightlighted on the client record.' %}</p>
     </div>
     {{ form.alert }}
 </div>

--- a/src/member/templates/client/partials/forms/emergency_contact.html
+++ b/src/member/templates/client/partials/forms/emergency_contact.html
@@ -1,3 +1,4 @@
+{% load i18n %}
 <h4 class="ui dividing header">{{ _('Emergency contact') }}</h4>
 
 <div class="ui center aligned basic segment">
@@ -12,7 +13,7 @@
     {{ _('Or') }}
   </div>
   <div class="ui teal labeled icon button add emergency contact member">
-    Create new emergency contact
+    {% trans 'Create new emergency contact' %}
     <i class="add icon"></i>
   </div>
 

--- a/src/member/templates/client/partials/forms/payment_information.html
+++ b/src/member/templates/client/partials/forms/payment_information.html
@@ -1,3 +1,4 @@
+{% load i18n %}
 <h4 class="ui dividing header">{{ _('Billing information') }}</h4>
 
 <div class="field">
@@ -22,7 +23,7 @@
     {{ _('Or') }}
   </div>
   <div class="ui teal labeled icon button add payment member">
-    Create new payment member
+    {% trans 'Create new payment member' %}
     <i class="add icon"></i>
   </div>
 

--- a/src/member/templates/client/partials/forms/referent_information.html
+++ b/src/member/templates/client/partials/forms/referent_information.html
@@ -1,3 +1,4 @@
+{% load i18n %}
 <h4 class="ui dividing header">{{ _('Identity') }}</h4>
 
 <div class="ui center aligned basic segment">
@@ -12,7 +13,7 @@
     {{ _('Or') }}
   </div>
   <div class="ui teal labeled icon button add referent member">
-    Create new referent member
+    {% trans 'Create new referent member' %}
     <i class="add icon"></i>
   </div>
 
@@ -56,7 +57,7 @@
 
 <div class="field {% if form.referral_reason.errors %} error {% endif %}">
     <div class="ui message attached">
-        <p>Please describe the referral reason(s)</p>
+        <p>{% trans 'Please describe the referral reason(s)' %}</p>
     </div>
     {{ form.referral_reason }}
 </div>


### PR DESCRIPTION
*Improves #60 by adding trans tags in the client app.*

### Changes proposed in this pull request:

* Adding `{% trans '' %}` tags on all the strings in the client app.
  * File menu.html is being fixed in #416 so left untouched here.

### Status

- [X ] READY

