### PR TITLE
fix451 bugfix kitchen count repeated restricted item

### DIFF
--- a/src/order/models.py
+++ b/src/order/models.py
@@ -443,8 +443,11 @@ class Order(models.Model):
                 # should be a set
                 kitchen_list[row.cid].other_ingredients.append(
                     row.ingredient)
-            kitchen_list[row.cid].restricted_items.append(
-                row.restricted_item)
+            if (row.restricted_item not in
+                    kitchen_list[row.cid].restricted_items):
+                # remember restricted_item
+                kitchen_list[row.cid].restricted_items.append(
+                    row.restricted_item)
         # END FOR
 
         rows = db_sa_session.execute(q_day_pre)


### PR DESCRIPTION
## Fixes #451.

### Changes proposed in this pull request:

* order/models get_kitchen_items() : bugfix

### Status

- [X] READY

### How to verify this change

- Use admin to enter data such that a client has restricted item = "pork" that is incompatible with 3 ingredients (ex. ground pork, pork sausage, ham).
- Run Kitchen Count Report with Ginger Pork as main dish and see that "pork" is present only once for this client in the last column.

