### PR TITLE
Feature/custom 404

### DIFF
--- a/src/sous-chef/locale/en/LC_MESSAGES/django.po
+++ b/src/sous-chef/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-14 20:54+0000\n"
+"POT-Creation-Date: 2016-09-14 23:04+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,6 +16,22 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+
+#: sous-chef/templates/404.html:4 sous-chef/templates/404.html:6
+msgid "Page not found"
+msgstr ""
+
+#: sous-chef/templates/404.html:7
+msgid "We couldn't find the page you are looking for."
+msgstr ""
+
+#: sous-chef/templates/404.html:10
+msgid "Go back from where you came from"
+msgstr ""
+
+#: sous-chef/templates/404.html:11 sous-chef/templates/404.html:14
+msgid "Go back to homepage"
+msgstr ""
 
 #: sous-chef/templates/base.html:9 sous-chef/templates/splash.html:9
 msgid "Sous-Chef"

--- a/src/sous-chef/locale/fr/LC_MESSAGES/django.po
+++ b/src/sous-chef/locale/fr/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-14 20:54+0000\n"
+"POT-Creation-Date: 2016-09-14 23:04+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language-Team: French (https://www.transifex.com/savoirfairelinux/"
 "teams/63058/fr/)\n"
@@ -17,6 +17,22 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#: sous-chef/templates/404.html:4 sous-chef/templates/404.html:6
+msgid "Page not found"
+msgstr "La page demandée est introuvable"
+
+#: sous-chef/templates/404.html:7
+msgid "We couldn't find the page you are looking for."
+msgstr "Nous n'avons pas réussi à trouver la page demandée."
+
+#: sous-chef/templates/404.html:10
+msgid "Go back from where you came from"
+msgstr "Retournez d'où vous venez"
+
+#: sous-chef/templates/404.html:11 sous-chef/templates/404.html:14
+msgid "Go back to homepage"
+msgstr "Retournez à la page d'accueil"
 
 #: sous-chef/templates/base.html:9 sous-chef/templates/splash.html:9
 msgid "Sous-Chef"

--- a/src/sous-chef/templates/404.html
+++ b/src/sous-chef/templates/404.html
@@ -1,0 +1,16 @@
+{% extends "base.html" %}
+{% load staticfiles i18n %}
+
+{% block title %}{% trans "Page not found" %}{% endblock %}
+{% block content %}
+    <h1>{% trans "Page not found" %}</h1>
+    <p>{% trans "We couldn't find the page you are looking for." %}</p>
+    {% if request.META.HTTP_REFERER %}
+        <ul>
+            <li><a href="{{ request.META.HTTP_REFERER }}">{% trans "Go back from where you came from" %}</a></li>
+            <li><a href="/">{% trans "Go back to homepage" %}</a></li>
+        </ul>
+    {% else %}
+        <p><a href="/">{% trans "Go back to homepage" %}</a></p>
+    {% endif %}
+{% endblock %}


### PR DESCRIPTION
## Fixes #391  

### Changes proposed in this pull request:

* Add a new 404.html template with basic message

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

If you want to see the custom 404 page, DEBUG needs to be set to False. Otherwise, you'll get the framework error output.

Static files are globally not properly found while DEBUG is False. Since it was a global issue and not something happening just in this specific template, I'll open an issue on the subject.

### New translatable strings

- [X] If applicable, I have included updated .po files with new strings (see http://goo.gl/kfBO7N)
