### PR TITLE
Feature/provide contact infos for client referent

### DIFF
--- a/src/member/forms.py
+++ b/src/member/forms.py
@@ -235,6 +235,24 @@ class MemberForm(forms.Form):
         required=False
     )
 
+    email = forms.CharField(
+        label='<i class="email icon"></i>',
+        widget=forms.TextInput(attrs={'placeholder': _('Email')}),
+        required=False,
+    )
+
+    work_phone = forms.CharField(
+        label='Work',
+        widget=forms.TextInput(attrs={'placeholder': _('Work phone')}),
+        required=False,
+    )
+
+    cell_phone = forms.CharField(
+        label='Cell',
+        widget=forms.TextInput(attrs={'placeholder': _('Cellular')}),
+        required=False,
+    )
+
     def clean(self):
         cleaned_data = super(MemberForm, self).clean()
 

--- a/src/member/templates/client/partials/forms/referent_information.html
+++ b/src/member/templates/client/partials/forms/referent_information.html
@@ -32,6 +32,29 @@
               {{form.lastname}}
           </div>
         </div>
+        <div class="field">
+          <label>Contact information</label>
+          <div class="three fields">
+            <div class="field">
+              <div class="ui left icon input">
+                <i class="at grey icon"></i>
+                {{form.email}}
+              </div>
+            </div>
+            <div class="field">
+              <div class="ui left icon input">
+                <i class="building icon"></i>
+                {{form.work_phone}}
+              </div>
+            </div>
+            <div class="field">
+              <div class="ui left icon input">
+                <i class="call icon"></i>
+                {{form.cell_phone}}
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/src/member/templates/client/partials/forms/referent_information.html
+++ b/src/member/templates/client/partials/forms/referent_information.html
@@ -37,7 +37,7 @@
           <div class="three fields">
             <div class="field">
               <div class="ui left icon input">
-                <i class="at grey icon"></i>
+                <i class="at icon"></i>
                 {{form.email}}
               </div>
             </div>

--- a/src/member/tests.py
+++ b/src/member/tests.py
@@ -538,6 +538,8 @@ class FormTestCase(TestCase):
             "client_wizard-current_step": "referent_information",
             "referent_information-firstname": "Referent",
             "referent_information-lastname": "Testing",
+            "referent_information-email": "referent@testing.com",
+            "referent_information-work_phone": "458-458-4584 #458",
             "referent_information-work_information": "CLSC",
             "referent_information-date": "2012-12-12",
             "referent_information-referral_reason": "Testing referral reason",
@@ -649,6 +651,16 @@ class FormTestCase(TestCase):
         self.assertEqual(
             client.client_referent.first().referent.lastname,
             "Testing"
+        )
+
+        # test referent contact infos (email and work phone)
+        self.assertEqual(
+            client.client_referent.first().referent.email,
+            "referent@testing.com"
+        )
+        self.assertEqual(
+            client.client_referent.first().referent.work_phone,
+            "458-458-4584 #458"
         )
 
         # test_referent_work_information:
@@ -786,6 +798,8 @@ class FormTestCase(TestCase):
             "client_wizard-current_step": "referent_information",
             "referent_information-firstname": "Same",
             "referent_information-lastname": "User",
+            # "referent_information-email": "same@user.com",
+            # "referent_information-work_phone": "514-514-5145 #514",
             "referent_information-work_information": "CLSC",
             "referent_information-date": "2012-06-06",
             "referent_information-referral_reason": "Testing referral reason",

--- a/src/member/tests.py
+++ b/src/member/tests.py
@@ -798,8 +798,6 @@ class FormTestCase(TestCase):
             "client_wizard-current_step": "referent_information",
             "referent_information-firstname": "Same",
             "referent_information-lastname": "User",
-            # "referent_information-email": "same@user.com",
-            # "referent_information-work_phone": "514-514-5145 #514",
             "referent_information-work_information": "CLSC",
             "referent_information-date": "2012-06-06",
             "referent_information-referral_reason": "Testing referral reason",

--- a/src/member/views.py
+++ b/src/member/views.py
@@ -597,26 +597,11 @@ class ClientWizard(NamedUrlSessionWizardView):
             ref_cell_phone = referent_information.cleaned_data.get(
                 "cell_phone", None)
             if ref_email:
-                ctc_email = Contact.objects.create(
-                    type=EMAIL,
-                    value=ref_email,
-                    member=referent,
-                )
-                ctc_email.save()
+                referent.add_contact_information(EMAIL, ref_email)
             if ref_work_phone:
-                ctc_work_phone = Contact.objects.create(
-                    type=WORK,
-                    value=ref_work_phone,
-                    member=referent,
-                )
-                ctc_work_phone.save()
+                referent.add_contact_information(WORK, ref_work_phone)
             if ref_cell_phone:
-                ctc_cell_phone = Contact.objects.create(
-                    type=CELL,
-                    value=ref_cell_phone,
-                    member=referent,
-                )
-                ctc_cell_phone.save()
+                referent.add_contact_information(CELL, ref_cell_phone)
 
         referencing = Referencing.objects.create(
             referent=referent,

--- a/src/member/views.py
+++ b/src/member/views.py
@@ -27,7 +27,7 @@ from member.models import (
     Route,
     Client_avoid_ingredient,
     Client_avoid_component,
-    HOME, CELL, EMAIL,
+    HOME, WORK, CELL, EMAIL,
 )
 from member.forms import (
     ClientScheduledStatusForm,
@@ -590,6 +590,33 @@ class ClientWizard(NamedUrlSessionWizardView):
                 lastname=referent_information.cleaned_data.get("lastname"),
             )
             referent.save()
+            ref_email = referent_information.cleaned_data.get(
+                "email", None)
+            ref_work_phone = referent_information.cleaned_data.get(
+                "work_phone", None)
+            ref_cell_phone = referent_information.cleaned_data.get(
+                "cell_phone", None)
+            if ref_email:
+                ctc_email = Contact.objects.create(
+                    type=EMAIL,
+                    value=ref_email,
+                    member=referent,
+                )
+                ctc_email.save()
+            if ref_work_phone:
+                ctc_work_phone = Contact.objects.create(
+                    type=WORK,
+                    value=ref_work_phone,
+                    member=referent,
+                )
+                ctc_work_phone.save()
+            if ref_cell_phone:
+                ctc_cell_phone = Contact.objects.create(
+                    type=CELL,
+                    value=ref_cell_phone,
+                    member=referent,
+                )
+                ctc_cell_phone.save()
 
         referencing = Referencing.objects.create(
             referent=referent,


### PR DESCRIPTION
## Fixes #449

### Changes proposed in this pull request:

* Provide 3 fields to fill contact informations when creating a new member as client referent

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

- When creating a new client, create a new member as referent, and fill one or more of these 3 contact fields
- You should see them when consulting client referent after creation

### Deployment notes and migration

- [ ] Migration is needed for this change

### New translatable strings

- [ ] If applicable, I have included updated .po files with new strings (see http://goo.gl/kfBO7N)

### Additional notes

*If applicable, explain the rationale behind your change.*
