### PR TITLE
Remove buggy Travis CI check for makemessages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,6 @@ install:
 script:
   - coverage run --omit=*.virtualenvs*,*virtualenv* src/manage.py test --settings=sous-chef.settings_test member meal order notification delivery note billing page
   - pep8 --count --show-source --exclude=migrations src/
-  # Run `makemessages` and report an error if it should have been run by the
-  # developer for this pull request.
-  - cd src && python3 manage.py makemessages -l fr -l en
-  # We allow for a 1-line difference since `makemessages` will change the
-  # timestamp within the file.
-  - git diff --numstat | awk '{if ($1>1 || $2>1) { print "***ERROR***\nLarge diff detected in", $3; print "Please see https://github.com/savoirfairelinux/sous-chef/blob/dev/docs/create_po_file.adoc"; exit 1 } else { exit 0 }}'
 
 after_success:
   - coveralls

--- a/docs/create_po_file.adoc
+++ b/docs/create_po_file.adoc
@@ -1,7 +1,6 @@
 ## Instructions for internationalization
 
 ### Updating .po files for every pull request, if applicable
-**READ this section if you're here because of a failing Travis CI check.**
 
 If commits in your pull request have introduced new translatable content, you must update the .po files and include them in your pull request.
 


### PR DESCRIPTION
## Removes Travis CI check

### Changes proposed in this pull request:

* Removes the Travis Check. It was buggy beyond repair.

### Status

- [X] READY

### Additional notes

Unfortunately, there was a bug with how travis ran the makemessages tool where it would always have a diff. I am not prepared to track it down, so I'm removing the check.

