### PR TITLE
fix455 meal labels initial version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ django-leaflet==0.18.1
 django-extra-views==0.8.0
 transifex-client>=0.12.2
 django-template-i18n-lint>=1.2.1
+pylabels==1.2.1

--- a/src/delivery/templates/kitchen_count.html
+++ b/src/delivery/templates/kitchen_count.html
@@ -18,6 +18,11 @@
 
 <div class="ui basic segment no-print">
     <a href="javascript:window.print()" class="ui labeled icon right big button"><i class="print icon"></i>{% trans 'Print the Report' %}</a>
+    {% if num_labels > 0 %}
+      <a class="big ui button" href="{% url 'delivery:mealLabels' %}">{% trans "Download Labels" %}</a>
+    {% else %}
+      <button type="button" disabled class="big ui button">{% trans "No Labels Found" %}</button>
+    {% endif %}
 </div>
 
 

--- a/src/delivery/tests.py
+++ b/src/delivery/tests.py
@@ -33,6 +33,24 @@ class KitchenCountReportTestCase(TestCase):
         response = self.client.get('/delivery/kitchen_count/2015/05/21/')
         self.assertTrue(b'SUBTOTAL' not in response.content)
 
+    def test_labels_show_restrictions(self):
+        """An ingredient we know will clash must be in the labels"""
+        # generate orders today
+        self.today = datetime.date.today()
+        clients = Client.active.all()
+        numorders = Order.create_orders_on_defaults(
+            self.today, self.today, clients)
+        Menu.create_menu_and_components(
+            self.today,
+            ['Ginger pork',
+             'Green Salad', 'Fruit Salad',
+             'Day s Dessert', 'Day s Diabetic Dessert',
+             'Day s Pudding', 'Day s Compote'])
+
+        self.client.get('/delivery/kitchen_count/')
+        response = self.client.get('/delivery/viewMealLabels/')
+        self.assertTrue('ReportLab' in repr(response.content))
+
 
 class ChooseDayMainDishIngredientsTestCase(TestCase):
 

--- a/src/delivery/urls.py
+++ b/src/delivery/urls.py
@@ -2,7 +2,7 @@ from django.conf.urls import url
 from django.utils.translation import ugettext_lazy as _
 
 from delivery.views import (Orderlist, MealInformation, RoutesInformation,
-                            KitchenCount, DeliveryRouteSheet)
+                            KitchenCount, MealLabels, DeliveryRouteSheet)
 from delivery.views import Orderlist, MealInformation, RoutesInformation
 from delivery.views import dailyOrders, refreshOrders, saveRoute
 
@@ -14,6 +14,7 @@ urlpatterns = [
     url(_(r'^kitchen_count/$'), KitchenCount.as_view(), name='kitchen_count'),
     url(_(r'^kitchen_count/(?P<year>\d{4})/(?P<month>\d{2})/(?P<day>\d+)/$'),
         KitchenCount.as_view(), name='kitchen_count_date'),
+    url(_(r'^viewMealLabels/$'), MealLabels.as_view(), name='mealLabels'),
     url(_(r'^route_sheet/(?P<id>\d+)/$'),
         DeliveryRouteSheet.as_view(), name='route_sheet_id'),
     url(_(r'^getDailyOrders/$'), dailyOrders, name='dailyOrders'),


### PR DESCRIPTION
## Fixes #455 (needs layout verification and adjustments) .

### Changes proposed in this pull request:

* delivery/views.py : generate labels file as pdf; download labels
* requirements.txt : pylabels package added (uses ReportLab)

### Status

- [X] READY (will adjust label positioning and size when I get actual sheet from SantropolRoulant)

### How to verify this change

- Run Kitchen Count as usual; then on Report page, click "Download labels"
