### PR TITLE
Add the option "Other" for the gender selection form.

### DIFF
--- a/src/member/models.py
+++ b/src/member/models.py
@@ -21,6 +21,7 @@ EMAIL = 'Email'
 GENDER_CHOICES = (
     ('F', _('Female')),
     ('M', _('Male')),
+    ('O', _('Other')),
 )
 
 CONTACT_TYPE_CHOICES = (


### PR DESCRIPTION
## Fixes #486

### Changes proposed in this pull request:

* Add the option "Other" for the gender selection form.

### Status

- [X] READY

### How to verify this change

When completing the client add form, there are a third option: "other" for clients who don't identify as male or female

Ref: issue #486