### PR TITLE
Fix issue-505 Footer overlay in Kitchen count.

### DIFF
--- a/src/delivery/templates/review_orders.html
+++ b/src/delivery/templates/review_orders.html
@@ -44,7 +44,6 @@
             </a>
         </div>
 
-
     </div>
 
 
@@ -66,7 +65,7 @@
                 {% trans 'Orders' %}
             </div>
         </div>
-    </div
+    </div>
 </div>
 
 


### PR DESCRIPTION
## Fixes #505  by...

### Changes proposed in this pull request:

* There was a wrong close div tag template view_orders.

### Status

- [X] READY

### How to verify this change

* Click on "kitchen count" tab
* The footer should not overlay the "Okay, i'm ready" button

Ref: issue-505