### PR TITLE
Remove hardcoded URL from javascript code, issue #494.

### DIFF
--- a/src/frontend/js/order.js
+++ b/src/frontend/js/order.js
@@ -27,7 +27,7 @@ $(function() {
     $('#id_delivery_dates').hide();
 
     $('#id_client').change(function() {
-        $.get('/member/client/' + $(this).val() + '/meals/preferences', function(data) {
+        $.get($(this).attr('data-url'), function(data) {
             if (!$.isEmptyObject(data)) {
                 $('#id_main_dish_default_quantity').val(data['maindish_q']);
                 $('#id_size_default').dropdown('set selected', data['maindish_s']);
@@ -50,5 +50,5 @@ $(function() {
             }
         });
     });
-    // --
+
 });

--- a/src/order/forms.py
+++ b/src/order/forms.py
@@ -1,5 +1,9 @@
 from django import forms
+from django.utils.encoding import force_text
+from django.utils.safestring import mark_safe
+from django.utils.html import format_html
 from django.utils.translation import ugettext_lazy as _
+from django.urls import reverse
 from extra_views import InlineFormSet
 
 from member.models import Client
@@ -16,6 +20,26 @@ class CreateOrderItem(InlineFormSet):
 
 class UpdateOrderItem(CreateOrderItem):
     extra = 0
+
+
+class BatchFormClientSelect(forms.Select):
+    def render_option(self, selected_choices, option_value, option_label):
+        if option_value is None:
+            option_value = ''
+        option_value = force_text(option_value)
+        if option_value in selected_choices:
+            selected_html = mark_safe(' selected="selected"')
+            if not self.allow_multiple_selected:
+                # Only allow for a single selection.
+                selected_choices.remove(option_value)
+        else:
+            selected_html = ''
+
+        data_url = reverse('member:client_meals_pref',
+                           kwargs={'pk': option_value}) if option_value else ''
+        return format_html('<option value="{}" data-url="{}"{}>{}</option>',
+                           option_value,
+                           data_url, selected_html, force_text(option_label))
 
 
 class CreateOrdersBatchForm(forms.Form):
@@ -41,7 +65,7 @@ class CreateOrdersBatchForm(forms.Form):
     client = forms.ModelChoiceField(
         required=True,
         label=_('Client'),
-        widget=forms.Select(attrs={'class': 'ui search dropdown'}),
+        widget=BatchFormClientSelect(attrs={'class': 'ui search dropdown'}),
         queryset=Client.objects.all(),
     )
 

--- a/src/order/templates/list.html
+++ b/src/order/templates/list.html
@@ -15,7 +15,7 @@
     <a href="{% url 'order:create' %}" class="ui big button">
         <i class="add icon"></i>{% trans 'New order' %}
     </a>
-    <a href="{% url 'order:createBatch' %}" class="ui big button">
+    <a href="{% url 'order:create_batch' %}" class="ui big button">
         <i class="add icon"></i>{% trans 'Multiple orders' %}
     </a>
     <div class="ui horizontal divider">

--- a/src/order/urls.py
+++ b/src/order/urls.py
@@ -16,7 +16,7 @@ urlpatterns = [
     url(_(r'^create/$'), CreateOrder.as_view(), name='create'),
     # Multiple orders as once
     url(_(r'^create/batch$'),
-        CreateOrdersBatch.as_view(), name='createBatch'),
+        CreateOrdersBatch.as_view(), name='create_batch'),
 
     url(_(r'^update/(?P<pk>\d+)/$'), UpdateOrder.as_view(), name='update'),
     url(

--- a/src/order/views.py
+++ b/src/order/views.py
@@ -108,7 +108,7 @@ class CreateOrder(AjaxableResponseMixin, CreateWithInlinesView):
 class CreateOrdersBatch(generic.FormView):
     form_class = CreateOrdersBatchForm
     template_name = "order/create_batch.html"
-    success_url = reverse_lazy('order:createBatch')
+    success_url = reverse_lazy('order:create_batch')
 
     @method_decorator(login_required)
     def dispatch(self, *args, **kwargs):


### PR DESCRIPTION
## Fixes #494 

### Changes proposed in this pull request:

* Remove hardcoded URL from javascript code

### Status

- [X] READY

### How to verify this change

* Search inside `frontend` application for hardcoded URL example `$.get('/member/client/' + $(this).val() + '/meals/preferences')` and verify that all hardcoded URL are removed.

### Additional notes

Add a custom Select class that inherits from the class form.Select
to add the data-url attribute to the options for the select #id_client
in the route : "order:create_batch"

Ref: issue #494