### PR TITLE
Feature/client list view blocktrans

### DIFF
--- a/src/member/locale/en/LC_MESSAGES/django.po
+++ b/src/member/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-10-27 20:41+0000\n"
+"POT-Creation-Date: 2016-11-11 16:20+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -111,7 +111,7 @@ msgstr ""
 msgid "Distance from Santropol"
 msgstr ""
 
-#: member/forms.py:132 member/templates/client/list.html:89
+#: member/forms.py:132 member/templates/client/list.html:92
 #: member/templates/client/partials/filters.html:16
 msgid "Route"
 msgstr ""
@@ -469,7 +469,7 @@ msgstr ""
 msgid "alert client"
 msgstr ""
 
-#: member/models.py:461 member/templates/client/list.html:56
+#: member/models.py:460
 msgid "route"
 msgstr ""
 
@@ -697,28 +697,29 @@ msgstr ""
 msgid "Or"
 msgstr ""
 
-#: member/templates/client/list.html:52 member/templates/client/list.html:96
+#: member/templates/client/list.html:52 member/templates/client/list.html:99
 #: member/templates/client/view/summary.html:36
 msgid "years old"
 msgstr ""
 
-#: member/templates/client/list.html:55
-msgid "is an"
-msgstr ""
-
 #: member/templates/client/list.html:56
-msgid "client on the"
+#, python-format
+msgid ""
+"\n"
+"                    %(member_firstname)s is an <strong>%(delivery_type)s</"
+"strong> client on the <strong>%(route)s</strong> route.\n"
+"                "
 msgstr ""
 
-#: member/templates/client/list.html:57
+#: member/templates/client/list.html:60
 msgid "This client is currently"
 msgstr ""
 
-#: member/templates/client/list.html:77 member/templates/client/list.html:114
+#: member/templates/client/list.html:80 member/templates/client/list.html:117
 msgid "Sorry, no result found."
 msgstr ""
 
-#: member/templates/client/list.html:86
+#: member/templates/client/list.html:89
 #: member/templates/client/partials/filters.html:7
 #: member/templates/client/partials/forms/basic_information.html:4
 #: member/templates/client/partials/forms/emergency_contact.html:27
@@ -727,24 +728,24 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: member/templates/client/list.html:87
+#: member/templates/client/list.html:90
 #: member/templates/client/partials/filters.html:22
 #: member/templates/client/partials/menu.html:11
 #: member/templates/client/view/orders.html:28
 msgid "Status"
 msgstr ""
 
-#: member/templates/client/list.html:88
+#: member/templates/client/list.html:91
 #: member/templates/client/partials/filters.html:28
 #: member/templates/client/partials/forms/dietary_restriction.html:13
 msgid "Delivery"
 msgstr ""
 
-#: member/templates/client/list.html:90
+#: member/templates/client/list.html:93
 msgid "Last update"
 msgstr ""
 
-#: member/templates/client/list.html:128
+#: member/templates/client/list.html:131
 msgid "of"
 msgstr ""
 

--- a/src/member/locale/fr/LC_MESSAGES/django.po
+++ b/src/member/locale/fr/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-10-27 20:41+0000\n"
+"POT-Creation-Date: 2016-11-11 16:20+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: savoirfairelinux <support@savoirfairelinux.com>, 2016\n"
 "Language-Team: French (https://www.transifex.com/savoirfairelinux/"
@@ -113,7 +113,7 @@ msgstr ""
 msgid "Distance from Santropol"
 msgstr "Distance du Santropol Roulant"
 
-#: member/forms.py:132 member/templates/client/list.html:89
+#: member/forms.py:132 member/templates/client/list.html:92
 #: member/templates/client/partials/filters.html:16
 msgid "Route"
 msgstr "Itinéraire"
@@ -478,7 +478,7 @@ msgstr "lien avec le contact d'urgence"
 msgid "alert client"
 msgstr "alertes client"
 
-#: member/models.py:461 member/templates/client/list.html:56
+#: member/models.py:460
 msgid "route"
 msgstr "itinéraire"
 
@@ -714,32 +714,31 @@ msgstr "Nouveau client"
 msgid "Or"
 msgstr "Ou"
 
-#: member/templates/client/list.html:52 member/templates/client/list.html:96
+#: member/templates/client/list.html:52 member/templates/client/list.html:99
 #: member/templates/client/view/summary.html:36
 msgid "years old"
 msgstr ""
 
-#: member/templates/client/list.html:55
-msgid "is an"
+#: member/templates/client/list.html:56
+#, python-format
+msgid ""
+"\n"
+"                    %(member_firstname)s is an <strong>%(delivery_type)s</"
+"strong> client on the <strong>%(route)s</strong> route.\n"
+"                "
 msgstr ""
 
-#: member/templates/client/list.html:56
-#, fuzzy
-#| msgid "client"
-msgid "client on the"
-msgstr "client"
-
-#: member/templates/client/list.html:57
+#: member/templates/client/list.html:60
 #, fuzzy
 #| msgid "This field is required"
 msgid "This client is currently"
 msgstr "Ce champ est requis"
 
-#: member/templates/client/list.html:77 member/templates/client/list.html:114
+#: member/templates/client/list.html:80 member/templates/client/list.html:117
 msgid "Sorry, no result found."
 msgstr "Désolé, aucun résultat trouvé."
 
-#: member/templates/client/list.html:86
+#: member/templates/client/list.html:89
 #: member/templates/client/partials/filters.html:7
 #: member/templates/client/partials/forms/basic_information.html:4
 #: member/templates/client/partials/forms/emergency_contact.html:27
@@ -748,24 +747,24 @@ msgstr "Désolé, aucun résultat trouvé."
 msgid "Name"
 msgstr "Nom"
 
-#: member/templates/client/list.html:87
+#: member/templates/client/list.html:90
 #: member/templates/client/partials/filters.html:22
 #: member/templates/client/partials/menu.html:11
 #: member/templates/client/view/orders.html:28
 msgid "Status"
 msgstr "Statut"
 
-#: member/templates/client/list.html:88
+#: member/templates/client/list.html:91
 #: member/templates/client/partials/filters.html:28
 #: member/templates/client/partials/forms/dietary_restriction.html:13
 msgid "Delivery"
 msgstr "Livraison"
 
-#: member/templates/client/list.html:90
+#: member/templates/client/list.html:93
 msgid "Last update"
 msgstr "Dernière modification"
 
-#: member/templates/client/list.html:128
+#: member/templates/client/list.html:131
 msgid "of"
 msgstr ""
 

--- a/src/member/templates/client/list.html
+++ b/src/member/templates/client/list.html
@@ -52,8 +52,11 @@
             <span class="category">{{ obj.age }} {% trans "years old" %}</span>
         </div>
         <div class="description">
-            <p>{{ obj.member.firstname }} {% trans "is an" %} <strong>{{ obj.get_delivery_type_display }}</strong>
-                {% trans "client on the" %} <strong>{{ obj.route }}</strong> {% trans "route" %}.</p>
+            <p>
+                {% blocktrans with member_firstname=obj.member.firstname delivery_type=obj.get_delivery_type_display route=obj.route %}
+                    {{ member_firstname }} is an <strong>{{ delivery_type }}</strong> client on the <strong>{{ route }}</strong> route.
+                {% endblocktrans %}
+            </p>
                 <p>{% trans "This client is currently" %} <strong>{{ obj.get_status_display }}</strong>.</p>
             </div>
         </div>


### PR DESCRIPTION
## Fixes #509

A first change towards easier translatable strings.

By translating whole sentences instead of bits and pieces at a time, it will be easier to understand what needs to be translated and the `variable parts` will be movable inside the translated sentence.

This is important since sentences in various languages are not structure the same way. `variable` are not necessarily positioned at the same place from one translation to the other.

### Changes proposed in this pull request:

* Use of `blocktrans` in order to send whole sentences containing `placeholders`

### Status

- [ ] READY
- [ ] HOLD
- [X] WIP (Work-In-Progress)

### How to verify this change

* Fetch this branch and refresh (or go to) /member/list/ and see that the English version of client's description have not change.

### Deployment notes and migration

- [ ] Migration is needed for this change

### New translatable strings

- [X] If applicable, I have included updated .po files with new strings (see http://goo.gl/kfBO7N)

### Additional notes

This is still a work-in-progress, but I need the merge to receive feedback from @PascalPriori and if this technique will help him (and other translators) with translations.

Couldn't update https://www.transifex.com/savoirfairelinux/sous-chef by following instructions in https://github.com/savoirfairelinux/sous-chef/blob/dev/docs/create_po_file.adoc