### PR TITLE
Check that there are a valid member_contact.

### DIFF
--- a/src/member/views.py
+++ b/src/member/views.py
@@ -1210,6 +1210,7 @@ class ClientUpdateEmergencyContactInformation(ClientUpdateInformation):
         client = get_object_or_404(
             Client, pk=self.kwargs.get('pk')
         )
+        member_contact = client.emergency_contact.member_contact.first()
         initial.update({
             'firstname': None,
             'lastname': None,
@@ -1218,10 +1219,8 @@ class ClientUpdateEmergencyContactInformation(ClientUpdateInformation):
                 client.emergency_contact.firstname,
                 client.emergency_contact.lastname
             ),
-            'contact_type':
-                client.emergency_contact.member_contact.first().type,
-            'contact_value':
-                client.emergency_contact.member_contact.first().value,
+            'contact_type': member_contact.type if member_contact else None,
+            'contact_value': member_contact.value if member_contact else None,
             'relationship':
                 client.emergency_contact_relationship
         })


### PR DESCRIPTION
## Fixes #517  by...

### Changes proposed in this pull request:

* Check the member_contact before access to type and value properties

### Status

- [X] READY

### How to verify this change

* step 1= Click on any client to open their file
* step 2= Click on EDIT down in the Emergency contact field
* step 3= Change the values and save

Check the member_contact before access to type and value properties, if there
are an emergency contact without contact information like Home phone, the page
for edit the client emergency contact crash.

Ref: issue-517