### PR TITLE
Fixed #534: extend manage.py generateorders - add option --days. with…

### DIFF
--- a/src/order/management/commands/generateorders.py
+++ b/src/order/management/commands/generateorders.py
@@ -1,7 +1,7 @@
 from django.core.management.base import BaseCommand
 from order.models import Order
 from member.models import Client
-from datetime import datetime
+from datetime import datetime, timedelta
 from django.contrib.admin.models import LogEntry, ADDITION, CHANGE
 
 
@@ -14,22 +14,38 @@ class Command(BaseCommand):
             'delivery_date',
             help='The date must be in the format YYYY-MM-DD',
         )
+        parser.add_argument(
+            '--days',
+            help=(
+                'The number of days to be created in advance.'
+                'There will not be duplicates.'
+            ),
+            default=1,
+            type=int
+        )
 
     def handle(self, *args, **options):
-        delivery_date = datetime.strptime(
+        start_date = datetime.strptime(
             options['delivery_date'], '%Y-%m-%d'
         ).date()
+        days = options['days']
 
         # Only active clients can receive orders
         clients = Client.active.all()
-        # Create the orders
-        numorders = Order.objects.auto_create_orders(delivery_date, clients)
-        # Log the execution
-        LogEntry.objects.log_action(
-            user_id=1, content_type_id=1,
-            object_id="", object_repr="Orders creation for "+str(
-                delivery_date.strftime('%Y-%m-%d %H:%M')),
-            action_flag=ADDITION,
-        )
-        print("Orders created: ", numorders,
-              "to be delivered on ", delivery_date, ".")
+
+        for i in range(days):
+            # Create the orders
+            delivery_date = start_date + timedelta(days=i)
+            numorders = Order.objects.auto_create_orders(
+                delivery_date, clients
+            )
+            # Log the execution
+            LogEntry.objects.log_action(
+                user_id=1, content_type_id=1,
+                object_id="", object_repr="Orders creation for "+str(
+                    delivery_date.strftime('%Y-%m-%d %H:%M')),
+                action_flag=ADDITION,
+            )
+            print("{0} orders created on {1}: to be delivered on {2}.".format(
+                numorders, start_date, delivery_date
+            ))


### PR DESCRIPTION
## Fixes #534 by lingxiaoyang
### Changes proposed in this pull request:

* Add option `--days` to `manage.py generateorders`, allowing batch order creation.
* Add unit test to ensure: 1. the command only works for active clients; 2. the command doesn't create duplicate orders.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

![image](https://cloud.githubusercontent.com/assets/8630726/20840295/c16446ca-b87d-11e6-889d-aad6d04ad180.png)

### Deployment notes and migration

No migration is needed for this change

### New translatable strings

None

### Additional notes

None