### PR TITLE
Fixed #542: fix client status change modal problems.

### DIFF
--- a/src/frontend/js/member.js
+++ b/src/frontend/js/member.js
@@ -60,18 +60,21 @@ $(function() {
                          success: function (xhr, ajaxOptions, thrownError) {
                              if ( $(xhr).find('.errorlist').length > 0 ) {
                                  $('.ui.modal.status').html(xhr);
-                                 $('.ui.modal.status').modal("show");
+                                 $('.ui.status_to.dropdown').dropdown();
                              } else {
+                                 $('.ui.modal.status').modal("hide");
                                  location.reload();
                              }
                          },
                      });
+                    return false; // don't hide modal until we have the response
                 },
                 // When denying modal, restore default value for status dropdown
                 onDeny: function($element) {
                     $('.ui.dropdown.status').dropdown('restore defaults');
+                    $('.ui.modal.status').modal("hide");
                 }
-            }).modal("show");
+            }).modal('setting', 'autofocus', false).modal("show");
         });
     });
 

--- a/src/frontend/js/order.js
+++ b/src/frontend/js/order.js
@@ -70,8 +70,8 @@ $(function() {
                 },
                 // When denying modal, restore default value for status dropdown
                 onDeny: function($element) {
+                    $('.ui.dropdown.status').dropdown('restore defaults');
                     $('.ui.modal.status').modal("hide");
-                    location.reload();
                 }
             }).modal('setting', 'autofocus', false).modal("show");
         });

--- a/src/member/views.py
+++ b/src/member/views.py
@@ -43,7 +43,7 @@ from member.models import (
     HOME, WORK, CELL, EMAIL,
 )
 from note.models import Note
-from order.mixins import AjaxableResponseMixin
+from order.mixins import FormValidAjaxableResponseMixin
 
 
 class ClientWizard(LoginRequiredMixin, NamedUrlSessionWizardView):
@@ -1305,7 +1305,10 @@ def geolocateAddress(request):
     return JsonResponse({'latitude': lat, 'longtitude': long})
 
 
-class ClientStatusScheduler(AjaxableResponseMixin, generic.CreateView):
+class ClientStatusScheduler(
+        FormValidAjaxableResponseMixin,
+        generic.CreateView
+):
     model = ClientScheduledStatus
     form_class = ClientScheduledStatusForm
     template_name = "client/update/status.html"


### PR DESCRIPTION
## Fixes #542 by lingxiaoyang

### Changes proposed in this pull request:

* Small frontend fix concerning the behaviour of status change modal window.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

On http://localhost:8000/member/view/611/information

Change status. Test for success and failure (wipe the value of Start Date, or fill in invalid values).

### Deployment notes and migration

none

### New translatable strings

none

### Additional notes

none
