### PR TITLE
cm: use standard print buttons on each step

### DIFF
--- a/src/delivery/templates/kitchen_count.html
+++ b/src/delivery/templates/kitchen_count.html
@@ -17,11 +17,17 @@
 
 
 <div class="ui basic segment no-print">
-    <a href="javascript:window.print()" class="ui labeled icon right big button"><i class="print icon"></i>{% trans 'Print the Report' %}</a>
+    <a href="javascript:window.print()" class="ui labeled icon right pink basic big button" title="{% trans 'Print the kitchen count report' %}">
+        <i class="print icon"></i>{% trans 'Kitchen Count' %}
+    </a>
     {% if num_labels > 0 %}
-      <a class="big ui button" href="{% url 'delivery:mealLabels' %}">{% trans "Download Labels" %}</a>
+      <a href="{% url 'delivery:mealLabels' %}" class="ui labeled icon right pink basic big button" title="{% trans 'Download the labels' %}">
+         <i class="download icon"></i>{% trans "Labels" %}
+      </a>
     {% else %}
-      <button type="button" disabled class="big ui button">{% trans "No Labels Found" %}</button>
+        <a href="{% url 'delivery:mealLabels' %}" class="ui disabled labeled icon right pink basic big button" title="{% trans 'No labels available' %}">
+           <i class="download icon"></i>{% trans "Labels" %}
+        </a>
     {% endif %}
 </div>
 

--- a/src/delivery/templates/organize_route.html
+++ b/src/delivery/templates/organize_route.html
@@ -22,6 +22,12 @@
     </div>
 </div>
 
+<div class="ui basic segment no-print">
+    <a href="javascript:window.print()" class="ui labeled icon right pink basic big button" title="{% trans 'Print the map and directions' %}">
+        <i class="print icon"></i>{% trans 'Map and Directions' %}
+    </a>
+</div>
+
 <div class="row">
   <div class="thirteen wide column" id="route_map"
         data-route="{{ route.id }}"
@@ -34,10 +40,10 @@
 </div>
 
 <a href="{% url 'delivery:route_sheet_id' id=route.id %}" class="ui big labeled icon button" title="{% trans 'Print the route sheet' %}">
-  <i class="print icon"></i>{% trans 'Route sheet' %}
+  <i class="list layout icon"></i>{% trans 'Route sheet' %}
 </a>
 <a href="{% url 'delivery:routes' %}" class="ui big labeled {% if orders == 0 %} disabled {% endif %} icon button" title="{% trans 'View routes list' %}">
-  <i class="list icon"></i>{% trans 'View routes' %}
+  <i class="chevron left icon"></i>{% trans 'View routes' %}
 </a>
 
 {% endblock %}

--- a/src/delivery/templates/route_sheet.html
+++ b/src/delivery/templates/route_sheet.html
@@ -15,6 +15,14 @@
     </div>
 </div>
 
+<div class="ui basic segment no-print">
+    <a href="javascript:window.print()" class="ui labeled icon right basic pink big button" title="{% trans 'Print the route sheet.' %}">
+        <i class="print icon"></i>{% trans 'Route Sheet' %}
+    </a>
+</div>
+
+<div class="ui row"></div>
+
 <table class="ui three column very basic celled table">
   <thead>
    <tr class="top aligned">
@@ -75,7 +83,7 @@
   <i class="marker icon"></i>{% trans 'Organize' %}
 </a>
 <a href="{% url 'delivery:routes' %}" class="ui big labeled {% if orders == 0 %} disabled {% endif %} icon button" title="{% trans 'View routes list' %}">
-  <i class="list icon"></i>{% trans 'View routes' %}
+  <i class="chevron left icon"></i>{% trans 'View routes' %}
 </a>
 
 </div>

--- a/src/delivery/templates/routes.html
+++ b/src/delivery/templates/routes.html
@@ -33,15 +33,15 @@
                   <i class="marker icon"></i>{% trans 'Organize' %}
               </a>
               <a href="{% url 'delivery:route_sheet_id' id=route.id %}" class="ui compact labeled {% if orders == 0 %} disabled {% endif %} icon button" title="{% trans 'Print the route sheet' %}">
-                  <i class="print icon"></i>{% trans 'Route sheet' %}
+                  <i class="list layout icon"></i>{% trans 'Route sheet' %}
               </a>
             </div>
             <i class="large location arrow icon"></i>
             <div class="content">
               <div class="header">{{ route.name }}</div>
               <div class="description">
-                  <i class="bicycle icon" title="{% trans 'Cycling map' %}"></i>
-                  <div class="ui circular label" title="{% trans 'Number of orders on this route' %}">{{ orders }} {% if orders > 1 %}stops{% else %}stop{% endif %}</div>
+                  <i class="bicycle circular icon" title="{% trans 'Cycling map' %}"></i>
+                  <div class="ui circular pink basic label" title="{% trans 'Number of orders on this route' %}">{{ orders }}</div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Fixes #535

### Changes proposed in this pull request:

A print button must be a labeled button with icon.
The title attribute must be set and explain which
artefact is going to be produced.

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

* Go through the kitchen count steps
