### PR TITLE
Fixed #533: organize route view retrieve manual changes

### DIFF
--- a/src/delivery/tests.py
+++ b/src/delivery/tests.py
@@ -262,10 +262,16 @@ class RouteSequencingTestCase(SousChefTestMixin, TestCase):
         response = self.client.post(reverse_lazy('delivery:save_route'),
                                     json.dumps(dic),
                                     content_type="application/json")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(b'OK' in response.content)
         response = self.client.get(
             '/delivery/getDailyOrders/?route=' +
             str(self.route_id) + '&if_exist_then_retrieve=true')
-        self.assertTrue(b'Dallaire' in response.content)
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode(response.charset)
+        waypoints = json.loads(content)['waypoints']
+        self.assertEqual(waypoints[0]['id'], mem_dal.id)
+        self.assertEqual(waypoints[1]['id'], mem_tay.id)
 
     def test_route_sequence_not_saved(self):
         """Attempt retrieving a route sequence that was not saved."""

--- a/src/delivery/tests.py
+++ b/src/delivery/tests.py
@@ -264,16 +264,17 @@ class RouteSequencingTestCase(SousChefTestMixin, TestCase):
                                     content_type="application/json")
         response = self.client.get(
             '/delivery/getDailyOrders/?route=' +
-            str(self.route_id) + '&mode=retrieve')
+            str(self.route_id) + '&if_exist_then_retrieve=true')
         self.assertTrue(b'Dallaire' in response.content)
 
     def test_route_sequence_not_saved(self):
         """Attempt retrieving a route sequence that was not saved."""
         route_id_none = Route.objects.get(name='Centre Sud').id
-        response = self.client.get(
-            '/delivery/getDailyOrders/?route=' +
-            str(route_id_none) + '&mode=retrieve')
-        self.assertTrue(b'Blondin' in response.content)
+        with self.assertRaises(Exception) as cm:
+            response = self.client.get(
+                '/delivery/getDailyOrders/?route=' +
+                str(route_id_none) + '&if_exist_then_retrieve=true')
+        self.assertIn('unknown', str(cm.exception))
 
     def test_get_orders_unknown_mode(self):
         """Route get orders with unknown transportation mode."""

--- a/src/frontend/js/custom-leaflet.js
+++ b/src/frontend/js/custom-leaflet.js
@@ -38,7 +38,7 @@ function getRouteWaypoints(routeId) {
     control.setWaypoints(waypoints);
 
     // Ajax call to get waypoint according route
-    $.get( "../getDailyOrders/?route="+routeId+"&mode=euclidean", function(data ) {
+    $.get( "../getDailyOrders/?route="+routeId+"&mode=euclidean&if_exist_then_retrieve=true", function(data ) {
         var deliveryPoints = L.Routing.Waypoint.extend({ member:"", address:""});
         // create an array of waypoint from ajax call
         for(var i in data.waypoints)


### PR DESCRIPTION
## Fixes #533 by lingxiaoyang

### Changes proposed in this pull request:

* Add GET parameter `if_exist_then_retrieve` for getting manual route changes.
* Add this parameter in JS

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

In "organize route" in kitchen count, it should initialize with optimized route. Then do manual changes and refresh. The order of delivery should remain the same.

### Deployment notes and migration

none

### New translatable strings

none

### Additional notes

none
