### PR TITLE
Fix 524

### DIFF
--- a/src/billing/locale/en/LC_MESSAGES/django.po
+++ b/src/billing/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-11-22 23:01+0000\n"
+"POT-Creation-Date: 2016-12-08 15:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,18 +17,17 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: billing/models.py:60
+#: billing/models.py:61
 msgid "total_amount"
 msgstr ""
 
-#: billing/models.py:92
+#: billing/models.py:123
 msgid "Search by name"
 msgstr ""
 
 #: billing/templates/billing/add.html:5 billing/templates/billing/add.html:10
 #: billing/templates/billing/list.html:5
 #: billing/templates/billing/list.html:10
-#: billing/templates/billing/view.html:5
 msgid "Billing"
 msgstr ""
 
@@ -50,7 +49,7 @@ msgid "2. Create Billing"
 msgstr ""
 
 #: billing/templates/billing/add.html:60
-#: billing/templates/billing/view.html:24
+#: billing/templates/billing/view_orders.html:44
 msgid "Order"
 msgstr ""
 
@@ -60,7 +59,8 @@ msgid "Order\\"
 msgstr ""
 
 #: billing/templates/billing/add.html:63
-#: billing/templates/billing/view.html:27
+#: billing/templates/billing/view.html:24
+#: billing/templates/billing/view_orders.html:47
 msgid "Client"
 msgstr ""
 
@@ -69,12 +69,12 @@ msgid "Quickly access the client\\"
 msgstr ""
 
 #: billing/templates/billing/add.html:66
-#: billing/templates/billing/view.html:30
+#: billing/templates/billing/view_orders.html:50
 msgid "Delivery Date"
 msgstr ""
 
 #: billing/templates/billing/add.html:69
-#: billing/templates/billing/view.html:33
+#: billing/templates/billing/view_orders.html:53
 msgid "Status"
 msgstr ""
 
@@ -84,13 +84,14 @@ msgstr ""
 
 #: billing/templates/billing/add.html:72
 #: billing/templates/billing/list.html:56
-#: billing/templates/billing/view.html:36
+#: billing/templates/billing/view_orders.html:56
 msgid "Amount"
 msgstr ""
 
 #: billing/templates/billing/add.html:75
 #: billing/templates/billing/list.html:62
-#: billing/templates/billing/view.html:39
+#: billing/templates/billing/view.html:36
+#: billing/templates/billing/view_orders.html:59
 msgid "Actions"
 msgstr ""
 
@@ -127,6 +128,7 @@ msgid "Billing Period"
 msgstr ""
 
 #: billing/templates/billing/list.html:39
+#: billing/templates/billing/view_orders.html:30
 msgid "Reset"
 msgstr ""
 
@@ -169,39 +171,100 @@ msgstr ""
 msgid "Revenues"
 msgstr ""
 
-#: billing/templates/billing/view.html:9
-msgid "Billing Details"
+#: billing/templates/billing/view.html:5 billing/templates/billing/view.html:9
+msgid "Billing Summary"
 msgstr ""
 
 #: billing/templates/billing/view.html:19
+#: billing/templates/billing/view_orders.html:37
 msgid "Print"
 msgstr ""
 
 #: billing/templates/billing/view.html:25
-msgid "A unique identifier for the order."
-msgstr ""
-
-#: billing/templates/billing/view.html:28
+#: billing/templates/billing/view_orders.html:48
 msgid "Quickly access the client file."
 msgstr ""
 
+#: billing/templates/billing/view.html:27
+msgid "Total Orders"
+msgstr ""
+
+#: billing/templates/billing/view.html:28
+msgid "Number of orders in total in this billing period."
+msgstr ""
+
+#: billing/templates/billing/view.html:30
+msgid "Total Main Dishes"
+msgstr ""
+
 #: billing/templates/billing/view.html:31
-msgid "The delivery date planned for the order."
+msgid "Number of main dishes in total in this billing period."
+msgstr ""
+
+#: billing/templates/billing/view.html:33
+msgid "Total Amount"
 msgstr ""
 
 #: billing/templates/billing/view.html:34
-msgid "Display only included orders."
+msgid "Total amount in this billing period."
 msgstr ""
 
-#: billing/templates/billing/view.html:37
-msgid "Total amount in $CAD."
+#: billing/templates/billing/view.html:46
+msgid "Regular"
 msgstr ""
 
-#: billing/templates/billing/view.html:57
+#: billing/templates/billing/view.html:48
+msgid "and"
+msgstr ""
+
+#: billing/templates/billing/view.html:50
+msgid "Large"
+msgstr ""
+
+#: billing/templates/billing/view.html:56
+#: billing/templates/billing/view.html:66
+msgid "View Orders"
+msgstr ""
+
+#: billing/templates/billing/view.html:63
+#: billing/templates/billing/view_orders.html:77
 msgid "Total"
 msgstr ""
 
-#: billing/views.py:58
+#: billing/templates/billing/view_orders.html:5
+#: billing/templates/billing/view_orders.html:9
+msgid "Billing Order Details"
+msgstr ""
+
+#: billing/templates/billing/view_orders.html:17
+msgid "Client Name"
+msgstr ""
+
+#: billing/templates/billing/view_orders.html:29
+msgid "Apply Filter"
+msgstr ""
+
+#: billing/templates/billing/view_orders.html:36
+msgid "Back to summary"
+msgstr ""
+
+#: billing/templates/billing/view_orders.html:45
+msgid "A unique identifier for the order."
+msgstr ""
+
+#: billing/templates/billing/view_orders.html:51
+msgid "The delivery date planned for the order."
+msgstr ""
+
+#: billing/templates/billing/view_orders.html:54
+msgid "Display only included orders."
+msgstr ""
+
+#: billing/templates/billing/view_orders.html:57
+msgid "Total amount in $CAD."
+msgstr ""
+
+#: billing/views.py:59
 #, python-format
 msgid ""
 "The billing with the identifier #%s             has been successfully "

--- a/src/billing/locale/fr/LC_MESSAGES/django.po
+++ b/src/billing/locale/fr/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-11-22 23:01+0000\n"
+"POT-Creation-Date: 2016-12-08 15:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: PascalPriori <pascal.priori@savoirfairelinux.com>, 2016\n"
 "Language-Team: French (https://www.transifex.com/savoirfairelinux/"
@@ -19,18 +19,17 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: billing/models.py:60
+#: billing/models.py:61
 msgid "total_amount"
 msgstr "total_amount"
 
-#: billing/models.py:92
+#: billing/models.py:123
 msgid "Search by name"
 msgstr "Recherche par nom"
 
 #: billing/templates/billing/add.html:5 billing/templates/billing/add.html:10
 #: billing/templates/billing/list.html:5
 #: billing/templates/billing/list.html:10
-#: billing/templates/billing/view.html:5
 msgid "Billing"
 msgstr "Facturation"
 
@@ -54,7 +53,7 @@ msgid "2. Create Billing"
 msgstr ""
 
 #: billing/templates/billing/add.html:60
-#: billing/templates/billing/view.html:24
+#: billing/templates/billing/view_orders.html:44
 #, fuzzy
 #| msgid "order id"
 msgid "Order"
@@ -66,7 +65,8 @@ msgid "Order\\"
 msgstr ""
 
 #: billing/templates/billing/add.html:63
-#: billing/templates/billing/view.html:27
+#: billing/templates/billing/view.html:24
+#: billing/templates/billing/view_orders.html:47
 msgid "Client"
 msgstr "Client"
 
@@ -75,12 +75,12 @@ msgid "Quickly access the client\\"
 msgstr ""
 
 #: billing/templates/billing/add.html:66
-#: billing/templates/billing/view.html:30
+#: billing/templates/billing/view_orders.html:50
 msgid "Delivery Date"
 msgstr ""
 
 #: billing/templates/billing/add.html:69
-#: billing/templates/billing/view.html:33
+#: billing/templates/billing/view_orders.html:53
 msgid "Status"
 msgstr ""
 
@@ -90,13 +90,14 @@ msgstr ""
 
 #: billing/templates/billing/add.html:72
 #: billing/templates/billing/list.html:56
-#: billing/templates/billing/view.html:36
+#: billing/templates/billing/view_orders.html:56
 msgid "Amount"
 msgstr "Montant"
 
 #: billing/templates/billing/add.html:75
 #: billing/templates/billing/list.html:62
-#: billing/templates/billing/view.html:39
+#: billing/templates/billing/view.html:36
+#: billing/templates/billing/view_orders.html:59
 msgid "Actions"
 msgstr "Actions"
 
@@ -137,6 +138,7 @@ msgid "Billing Period"
 msgstr "Facturation"
 
 #: billing/templates/billing/list.html:39
+#: billing/templates/billing/view_orders.html:30
 msgid "Reset"
 msgstr "Réinitialiser"
 
@@ -181,43 +183,112 @@ msgstr ""
 msgid "Revenues"
 msgstr ""
 
-#: billing/templates/billing/view.html:9
+#: billing/templates/billing/view.html:5 billing/templates/billing/view.html:9
 #, fuzzy
 #| msgid "Billing"
-msgid "Billing Details"
+msgid "Billing Summary"
 msgstr "Facturation"
 
 #: billing/templates/billing/view.html:19
+#: billing/templates/billing/view_orders.html:37
 msgid "Print"
 msgstr ""
 
 #: billing/templates/billing/view.html:25
-msgid "A unique identifier for the order."
-msgstr ""
-
-#: billing/templates/billing/view.html:28
+#: billing/templates/billing/view_orders.html:48
 msgid "Quickly access the client file."
 msgstr ""
 
+#: billing/templates/billing/view.html:27
+msgid "Total Orders"
+msgstr ""
+
+#: billing/templates/billing/view.html:28
+msgid "Number of orders in total in this billing period."
+msgstr ""
+
+#: billing/templates/billing/view.html:30
+msgid "Total Main Dishes"
+msgstr ""
+
 #: billing/templates/billing/view.html:31
+msgid "Number of main dishes in total in this billing period."
+msgstr ""
+
+#: billing/templates/billing/view.html:33
+#, fuzzy
+#| msgid "total_amount"
+msgid "Total Amount"
+msgstr "total_amount"
+
+#: billing/templates/billing/view.html:34
+msgid "Total amount in this billing period."
+msgstr ""
+
+#: billing/templates/billing/view.html:46
+msgid "Regular"
+msgstr ""
+
+#: billing/templates/billing/view.html:48
+msgid "and"
+msgstr ""
+
+#: billing/templates/billing/view.html:50
+msgid "Large"
+msgstr ""
+
+#: billing/templates/billing/view.html:56
+#: billing/templates/billing/view.html:66
+#, fuzzy
+#| msgid "order id"
+msgid "View Orders"
+msgstr "# de commande"
+
+#: billing/templates/billing/view.html:63
+#: billing/templates/billing/view_orders.html:77
+msgid "Total"
+msgstr ""
+
+#: billing/templates/billing/view_orders.html:5
+#: billing/templates/billing/view_orders.html:9
+#, fuzzy
+#| msgid "Billing"
+msgid "Billing Order Details"
+msgstr "Facturation"
+
+#: billing/templates/billing/view_orders.html:17
+#, fuzzy
+#| msgid "client name"
+msgid "Client Name"
+msgstr "Nom du client"
+
+#: billing/templates/billing/view_orders.html:29
+msgid "Apply Filter"
+msgstr ""
+
+#: billing/templates/billing/view_orders.html:36
+msgid "Back to summary"
+msgstr ""
+
+#: billing/templates/billing/view_orders.html:45
+msgid "A unique identifier for the order."
+msgstr ""
+
+#: billing/templates/billing/view_orders.html:51
 msgid "The delivery date planned for the order."
 msgstr ""
 
-#: billing/templates/billing/view.html:34
+#: billing/templates/billing/view_orders.html:54
 msgid "Display only included orders."
 msgstr ""
 
-#: billing/templates/billing/view.html:37
+#: billing/templates/billing/view_orders.html:57
 #, fuzzy
 #| msgid "total_amount"
 msgid "Total amount in $CAD."
 msgstr "total_amount"
 
-#: billing/templates/billing/view.html:57
-msgid "Total"
-msgstr ""
-
-#: billing/views.py:58
+#: billing/views.py:59
 #, python-format
 msgid ""
 "The billing with the identifier #%s             has been successfully "
@@ -237,9 +308,6 @@ msgstr ""
 
 #~ msgid "Date"
 #~ msgstr "Date"
-
-#~ msgid "client name"
-#~ msgstr "Nom du client"
 
 #~ msgid "order date"
 #~ msgstr "Date de commande"

--- a/src/billing/templates/billing/print_summary.html
+++ b/src/billing/templates/billing/print_summary.html
@@ -1,0 +1,61 @@
+{% load i18n %}
+{% load static %}
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>{% trans 'Billing Summary' %} ({{billing.billing_period|date:"F Y"}})</title>
+    <style>
+      table {width: 100%;border-collapse:collapse}
+      table th {text-align:left}
+      table tr {border-bottom: 1px solid black}
+      @media only screen {
+        body {max-width:1024px}  /* for display */
+      }
+      @media only print {
+        .no-print {display:none!important;visilibity:hidden!important}
+      }
+    </style>
+  </head>
+  <body>
+    <h1 class="ui header">{% trans "Billing Summary" %}</h1>
+    <h3>{{billing.billing_period|date:"F Y"}}</h3>
+    <button onclick="javascript:window.print()" class="no-print">{% trans 'Print' %}</button>
+    <table>
+      <thead>
+        <tr>
+          <th>{% trans 'Client' %}</th>
+          <th>{% trans 'Total Orders' %}</th>
+          <th>{% trans 'Total Main Dishes' %}</th>
+          <th>{% trans 'Total Amount' %}</th>
+        </tr>
+      </thead>
+      <tfoot>
+        <tr>
+          <th colspan="3">{% trans "Total" %}</th>
+          <th>${{ billing.total_amount }}</th>
+        </tr>
+      </tfoot>
+      <tbody>
+        {% for client, client_summary in billing_summary %}
+        <tr>
+          <td>{{client}}</td>
+          <td>{{client_summary.total_orders}}</td>
+          <td>
+            {% with client_summary.total_main_dishes as tmd %}
+            {% if tmd.R > 0 %}
+            {{ tmd.R }} {% trans 'Regular' %}
+            {% endif %}
+            {% if tmd.R > 0 and tmd.L > 0 %}{% trans 'and' %}{% endif %}
+            {% if tmd.L > 0 %}
+            {{ tmd.L }} {% trans 'Large' %}
+            {% endif %}
+            {% endwith %}
+          </td>
+          <td>${{client_summary.total_amount}}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </body>
+</html>

--- a/src/billing/templates/billing/view.html
+++ b/src/billing/templates/billing/view.html
@@ -16,29 +16,40 @@
     <div class="ui row">
         {% include 'billing/partials/statistics.html' with orders=billing.orders.all %}
     </div>
-    <a href="javascript:window.print()" class="ui labeled icon right big button"><i class="print icon"></i>{% trans 'Print' %}</a>
+    <a href="?print=yes" target="_blank" class="ui labeled icon right big button"><i class="print icon"></i>{% trans 'Print' %}</a>
 </div>
 
-<table class="ui very basic stripped celled table">
+<table class="ui very basic compact celled table">
   <thead>
-    <th class="">{% trans 'Client' %}
-        <i class="help-text question grey icon link" data-content="{% trans 'Quickly access the client file.' %}"></i>
-    </th>
-    <th class="">{% trans 'Total Orders' %}
-        <i class="help-text question grey icon link" data-content="{% trans 'Number of orders in total in this billing period.' %}"></i>
-    </th>
-    <th class="">{% trans 'Total Main Dishes' %}
-        <i class="help-text question grey icon link" data-content="{% trans 'Number of main dishes in total in this billing period.' %}"></i>
-    </th>
-    <th class="">{% trans 'Total Amount' %}
-        <i class="help-text question grey icon link" data-content="{% trans 'Total amount in this billing period.' %}"></i>
-    </th>
-    <th class="">{% trans 'Actions' %}</th>
+    <tr>
+      <th class="">{% trans 'Client' %}
+        <i class="help-text question grey icon link no-print" data-content="{% trans 'Quickly access the client file.' %}"></i>
+      </th>
+      <th class="">{% trans 'Total Orders' %}
+        <i class="help-text question grey icon link no-print" data-content="{% trans 'Number of orders in total in this billing period.' %}"></i>
+      </th>
+      <th class="">{% trans 'Total Main Dishes' %}
+        <i class="help-text question grey icon link no-print" data-content="{% trans 'Number of main dishes in total in this billing period.' %}"></i>
+      </th>
+      <th class="">{% trans 'Total Amount' %}
+        <i class="help-text question grey icon link no-print" data-content="{% trans 'Total amount in this billing period.' %}"></i>
+      </th>
+      <th class="no-print">{% trans 'Actions' %}</th>
+    </tr>
   </thead>
+  <tfoot>
+    <tr>
+      <th colspan="3">{% trans "Total" %}</th>
+      <th class="left aligned"><i class="dollar icon"></i>{{ billing.total_amount }}</th>
+      <th class="no-print">
+        <a class="ui icon button"  href="{% url 'billing:view_orders' pk=billing.id %}">{% trans 'View Orders' %}</a>
+      </th>
+    </tr>
+  </tfoot>
   <tbody>
     {% for client, client_summary in billing_summary %}
     <tr>
-      <td><a href="{% url 'member:client_information' pk=client.id %}">{{client}}</td>
+      <td><a href="{% url 'member:client_information' pk=client.id %}">{{client}}</a></td>
       <td>{{client_summary.total_orders}}</td>
       <td>
         {% with client_summary.total_main_dishes as tmd %}
@@ -52,20 +63,11 @@
         {% endwith %}
       </td>
       <td class=""><i class="dollar icon"></i>{{client_summary.total_amount}}</td>
-      <td>
+      <td class="no-print">
         <a class="ui icon button"  href="{% url 'billing:view_orders' pk=billing.id %}?client={{ client.id }}">{% trans 'View Orders' %}</a>
       </td>
     </tr>
     {% endfor %}
   </tbody>
-  <tfoot>
-      <tr>
-          <th colspan="3">{% trans "Total" %}</th>
-          <th class="left aligned"><i class="dollar icon"></i>{{ billing.total_amount }}</th>
-          <th>
-            <a class="ui icon button"  href="{% url 'billing:view_orders' pk=billing.id %}">{% trans 'View Orders' %}</a>
-          </th>
-      </tr>
-  </tfoot>
 </table>
 {% endblock %}

--- a/src/billing/templates/billing/view.html
+++ b/src/billing/templates/billing/view.html
@@ -2,11 +2,11 @@
 {% load i18n %}
 {% load static %}
 
-{% block title %}{% trans 'Billing' %}{% endblock %}
+{% block title %}{% trans 'Billing Summary' %} ({{billing.billing_period|date:"F Y"}}){% endblock %}
 {% block content %}
 
 <div class="ui secondary pointing fluid menu">
-    <h1 class="ui header">{% trans "Billing Details" %}</h1>
+    <h1 class="ui header">{% trans "Billing Summary" %}</h1>
     <div class="right menu">
       <div class="ui item"><h3><i class="calendar icon"></i>{{billing.billing_period|date:"F Y"}}</h3></div>
     </div>
@@ -21,33 +21,39 @@
 
 <table class="ui very basic stripped celled table">
   <thead>
-    <th class="">{% trans 'Order' %}
-            <i class="help-text question grey icon link" data-content="{% trans 'A unique identifier for the order.' %}"></i>
-    </th>
     <th class="">{% trans 'Client' %}
         <i class="help-text question grey icon link" data-content="{% trans 'Quickly access the client file.' %}"></i>
     </th>
-    <th class="">{% trans 'Delivery Date' %}
-        <i class="help-text question grey icon link" data-content="{% trans 'The delivery date planned for the order.' %}"></i>
+    <th class="">{% trans 'Total Orders' %}
+        <i class="help-text question grey icon link" data-content="{% trans 'Number of orders in total in this billing period.' %}"></i>
     </th>
-    <th class="center aligned">{% trans 'Status' %}
-        <i class="help-text question grey icon link" data-content="{% trans 'Display only included orders.' %}"></i>
+    <th class="">{% trans 'Total Main Dishes' %}
+        <i class="help-text question grey icon link" data-content="{% trans 'Number of main dishes in total in this billing period.' %}"></i>
     </th>
-    <th class="center aligned">{% trans 'Amount' %}
-        <i class="help-text question grey icon link" data-content="{% trans 'Total amount in $CAD.' %}"></i>
+    <th class="">{% trans 'Total Amount' %}
+        <i class="help-text question grey icon link" data-content="{% trans 'Total amount in this billing period.' %}"></i>
     </th>
     <th class="">{% trans 'Actions' %}</th>
   </thead>
   <tbody>
-    {% for order in billing.orders.all %}
+    {% for client, client_summary in billing_summary %}
     <tr>
-      <td><i class="hashtag icon"></i>{{order.id}}</td>
-      <td><a href="{% url 'member:view' pk=order.client.id %}">{{order.client}}
-      <td>{{order.delivery_date}}</td>
-      <td class="center aligned">{{order.get_status_display}}</td>
-      <td class="center aligned"><i class="dollar icon"></i>{{order.price}}</td>
+      <td><a href="{% url 'member:client_information' pk=client.id %}">{{client}}</td>
+      <td>{{client_summary.total_orders}}</td>
       <td>
-        <a class="ui basic icon button"  href="{% url 'order:view' pk=order.id %}"><i class="icon unhide"></i></a>
+        {% with client_summary.total_main_dishes as tmd %}
+        {% if tmd.R > 0 %}
+        {{ tmd.R }} {% trans 'Regular' %}
+        {% endif %}
+        {% if tmd.R > 0 and tmd.L > 0 %}{% trans 'and' %}{% endif %}
+        {% if tmd.L > 0 %}
+        {{ tmd.L }} {% trans 'Large' %}
+        {% endif %}
+        {% endwith %}
+      </td>
+      <td class=""><i class="dollar icon"></i>{{client_summary.total_amount}}</td>
+      <td>
+        <a class="ui icon button"  href="{% url 'billing:view_orders' pk=billing.id %}?client={{ client.id }}">{% trans 'View Orders' %}</a>
       </td>
     </tr>
     {% endfor %}
@@ -55,7 +61,10 @@
   <tfoot>
       <tr>
           <th colspan="3">{% trans "Total" %}</th>
-          <th class="right aligned"><i class="dollar icon"></i>{{ billing.total_amount }}</th>
+          <th class="left aligned"><i class="dollar icon"></i>{{ billing.total_amount }}</th>
+          <th>
+            <a class="ui icon button"  href="{% url 'billing:view_orders' pk=billing.id %}">{% trans 'View Orders' %}</a>
+          </th>
       </tr>
   </tfoot>
 </table>

--- a/src/billing/templates/billing/view_orders.html
+++ b/src/billing/templates/billing/view_orders.html
@@ -1,0 +1,83 @@
+{% extends "base_billing.html" %}
+{% load i18n %}
+{% load static %}
+
+{% block title %}{% trans 'Billing Order Details' %} ({{billing.billing_period|date:"F Y"}}){% endblock %}
+{% block content %}
+
+<div class="ui secondary pointing fluid menu">
+    <h1 class="ui header">{% trans "Billing Order Details" %}</h1>
+    <div class="right menu">
+      <div class="ui item"><h3><i class="calendar icon"></i>{{billing.billing_period|date:"F Y"}}</h3></div>
+    </div>
+</div>
+
+<form action="" method="get" class="ui form">
+  <div class="inline fields">
+    <label>{% trans 'Client Name' %}</label>
+    <div class="field">
+      <select class="ui search dropdown" name="client" id="id_select_client">
+        <option value="" {% if not client %}selected{% endif %}>-----------</option>
+        {% for c in clients %}
+        <option value="{{ c.id }}" {% if client.id == c.id %}selected{% endif %}>
+          {{ c.member.firstname }} {{ c.member.lastname }}
+        </option>
+        {% endfor %}
+      </select>
+    </div>
+    <div class="field no-print">
+      <button class="ui yellow button" type="submit">{% trans 'Apply Filter' %}</button>
+      <a href="{% url 'billing:view_orders' pk=billing.id %}" class="ui basic button">{% trans 'Reset' %}</a>
+    </div>
+  </div>
+</form>
+
+<div class="ui basic row segment no-print">
+    <a href="{% url 'billing:view' pk=billing.id %}" class="ui labeled icon right big button"><i class="arrow left icon"></i>{% trans 'Back to summary' %}</a>
+    <a href="javascript:window.print()" class="ui labeled icon right big button"><i class="print icon"></i>{% trans 'Print' %}</a>
+</div>
+
+
+
+<table class="ui very basic stripped celled table">
+  <thead>
+    <th class="">{% trans 'Order' %}
+            <i class="help-text question grey icon link" data-content="{% trans 'A unique identifier for the order.' %}"></i>
+    </th>
+    <th class="">{% trans 'Client' %}
+        <i class="help-text question grey icon link" data-content="{% trans 'Quickly access the client file.' %}"></i>
+    </th>
+    <th class="">{% trans 'Delivery Date' %}
+        <i class="help-text question grey icon link" data-content="{% trans 'The delivery date planned for the order.' %}"></i>
+    </th>
+    <th class="center aligned">{% trans 'Status' %}
+        <i class="help-text question grey icon link" data-content="{% trans 'Display only included orders.' %}"></i>
+    </th>
+    <th class="center aligned">{% trans 'Amount' %}
+        <i class="help-text question grey icon link" data-content="{% trans 'Total amount in $CAD.' %}"></i>
+    </th>
+    <th class="">{% trans 'Actions' %}</th>
+  </thead>
+  <tbody>
+    {% for order in orders.all %}
+    <tr>
+      <td><i class="hashtag icon"></i>{{order.id}}</td>
+      <td><a href="{% url 'member:client_information' pk=order.client.id %}">{{order.client}}
+      <td>{{order.delivery_date}}</td>
+      <td class="center aligned">{{order.get_status_display}}</td>
+      <td class="center aligned"><i class="dollar icon"></i>{{order.price}}</td>
+      <td>
+        <a class="ui basic icon button"  href="{% url 'order:view' pk=order.id %}"><i class="icon unhide"></i></a>
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+  <tfoot>
+      <tr>
+          <th colspan="4">{% trans "Total" %}</th>
+          <th class="center aligned"><i class="dollar icon"></i>{{ total_amount }}</th>
+          <th></th>
+      </tr>
+  </tfoot>
+</table>
+{% endblock %}

--- a/src/billing/urls.py
+++ b/src/billing/urls.py
@@ -1,6 +1,7 @@
 from django.conf.urls import url
 from billing.views import (
-    BillingList, BillingCreate, BillingDelete, BillingView, BillingAdd
+    BillingList, BillingCreate, BillingDelete,
+    BillingSummaryView, BillingOrdersView, BillingAdd
 )
 from django.utils.translation import ugettext_lazy as _
 
@@ -8,6 +9,9 @@ urlpatterns = [
     url(r'^list/$', BillingList.as_view(), name="list"),
     url(r'^create/$', BillingCreate.as_view(), name="create"),
     url(r'^add/$', BillingAdd.as_view(), name="add"),
-    url(r'^view/(?P<pk>\d+)/$', BillingView.as_view(), name="view"),
+    url(r'^view/(?P<pk>\d+)/$',
+        BillingSummaryView.as_view(), name="view"),
+    url(r'^view/(?P<pk>\d+)/orders/$',
+        BillingOrdersView.as_view(), name="view_orders"),
     url(r'^delete/(?P<pk>\d+)/$', BillingDelete.as_view(), name='delete'),
 ]

--- a/src/billing/views.py
+++ b/src/billing/views.py
@@ -109,6 +109,13 @@ class BillingSummaryView(generic.DetailView):
     def dispatch(self, *args, **kwargs):
         return super(BillingSummaryView, self).dispatch(*args, **kwargs)
 
+    def get_template_names(self):
+        if self.request.method == "GET" and \
+           self.request.GET.get('print'):
+            return ['billing/print_summary.html']
+        else:
+            return super(BillingSummaryView, self).get_template_names()
+
     def get_context_data(self, **kwargs):
         context = super(BillingSummaryView, self).get_context_data(**kwargs)
 


### PR DESCRIPTION
## Fixes #524  by lingxiaoyang

### Changes proposed in this pull request:

* Add `.summary()` method on `models.Billing` to calculate client statistics.
* Add "Billing summary view" as the default billing detail view. (`/billing/view/{{pk}}`)
* Rename original billing detail view as "Billing Order Details" (`/billing/view/{{pk}}/orders`)
* Add GET parameter on "Billing Order Details" and add client filter in frontend.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

1. create a billing
2. go to http://localhost:8000/billing/list/
3. view this bill. It should be "billing summary"
4. click on "View Orders" to view order details.
5. the client filter should work as GET parameter `client={{client.id}}`

![image](https://cloud.githubusercontent.com/assets/8630726/20987225/cf0d6a52-bc99-11e6-978a-e37963708a03.png)

Click on "view orders" --->
![image](https://cloud.githubusercontent.com/assets/8630726/20987233/d6982dc0-bc99-11e6-8ab4-7d686eaceaa7.png)

### Deployment notes and migration

none

### New translatable strings

- [x] If applicable, I have included updated .po files with new strings (see http://goo.gl/kfBO7N)

### Additional notes

Frontend may need discussion.
