### PR TITLE
Fixed #562: wrong number of main dishes

### DIFF
--- a/src/billing/locale/en/LC_MESSAGES/django.po
+++ b/src/billing/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-12-08 15:31+0000\n"
+"POT-Creation-Date: 2016-12-13 20:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,7 +21,7 @@ msgstr ""
 msgid "total_amount"
 msgstr ""
 
-#: billing/models.py:123
+#: billing/models.py:127
 msgid "Search by name"
 msgstr ""
 
@@ -59,7 +59,7 @@ msgid "Order\\"
 msgstr ""
 
 #: billing/templates/billing/add.html:63
-#: billing/templates/billing/view.html:24
+#: billing/templates/billing/partials/summary.html:5
 #: billing/templates/billing/view_orders.html:47
 msgid "Client"
 msgstr ""
@@ -90,7 +90,7 @@ msgstr ""
 
 #: billing/templates/billing/add.html:75
 #: billing/templates/billing/list.html:62
-#: billing/templates/billing/view.html:36
+#: billing/templates/billing/partials/summary.html:17
 #: billing/templates/billing/view_orders.html:59
 msgid "Actions"
 msgstr ""
@@ -171,64 +171,67 @@ msgstr ""
 msgid "Revenues"
 msgstr ""
 
-#: billing/templates/billing/view.html:5 billing/templates/billing/view.html:9
-msgid "Billing Summary"
-msgstr ""
-
-#: billing/templates/billing/view.html:19
-#: billing/templates/billing/view_orders.html:37
-msgid "Print"
-msgstr ""
-
-#: billing/templates/billing/view.html:25
+#: billing/templates/billing/partials/summary.html:6
 #: billing/templates/billing/view_orders.html:48
 msgid "Quickly access the client file."
 msgstr ""
 
-#: billing/templates/billing/view.html:27
+#: billing/templates/billing/partials/summary.html:8
 msgid "Total Orders"
 msgstr ""
 
-#: billing/templates/billing/view.html:28
+#: billing/templates/billing/partials/summary.html:9
 msgid "Number of orders in total in this billing period."
 msgstr ""
 
-#: billing/templates/billing/view.html:30
+#: billing/templates/billing/partials/summary.html:11
 msgid "Total Main Dishes"
 msgstr ""
 
-#: billing/templates/billing/view.html:31
+#: billing/templates/billing/partials/summary.html:12
 msgid "Number of main dishes in total in this billing period."
 msgstr ""
 
-#: billing/templates/billing/view.html:33
+#: billing/templates/billing/partials/summary.html:14
 msgid "Total Amount"
 msgstr ""
 
-#: billing/templates/billing/view.html:34
+#: billing/templates/billing/partials/summary.html:15
 msgid "Total amount in this billing period."
 msgstr ""
 
-#: billing/templates/billing/view.html:46
-msgid "Regular"
+#: billing/templates/billing/partials/summary.html:22
+#: billing/templates/billing/view_orders.html:77
+msgid "Total"
 msgstr ""
 
-#: billing/templates/billing/view.html:48
-msgid "and"
-msgstr ""
-
-#: billing/templates/billing/view.html:50
-msgid "Large"
-msgstr ""
-
-#: billing/templates/billing/view.html:56
-#: billing/templates/billing/view.html:66
+#: billing/templates/billing/partials/summary.html:27
+#: billing/templates/billing/partials/summary.html:49
 msgid "View Orders"
 msgstr ""
 
-#: billing/templates/billing/view.html:63
-#: billing/templates/billing/view_orders.html:77
-msgid "Total"
+#: billing/templates/billing/partials/summary.html:39
+msgid "Regular"
+msgstr ""
+
+#: billing/templates/billing/partials/summary.html:41
+msgid "and"
+msgstr ""
+
+#: billing/templates/billing/partials/summary.html:43
+msgid "Large"
+msgstr ""
+
+#: billing/templates/billing/print_summary.html:7
+#: billing/templates/billing/print_summary.html:23
+#: billing/templates/billing/view.html:5 billing/templates/billing/view.html:9
+msgid "Billing Summary"
+msgstr ""
+
+#: billing/templates/billing/print_summary.html:25
+#: billing/templates/billing/view.html:19
+#: billing/templates/billing/view_orders.html:37
+msgid "Print"
 msgstr ""
 
 #: billing/templates/billing/view_orders.html:5
@@ -264,9 +267,15 @@ msgstr ""
 msgid "Total amount in $CAD."
 msgstr ""
 
-#: billing/views.py:59
+#: billing/views.py:61
 #, python-format
 msgid ""
 "The billing with the identifier #%s             has been successfully "
 "created."
+msgstr ""
+
+#: billing/views.py:171
+msgid ""
+"Warning: the order(s) below have not set a \"size\" for main dish and thus "
+"have been excluded in \"Total Main Dishes\" column."
 msgstr ""

--- a/src/billing/locale/fr/LC_MESSAGES/django.po
+++ b/src/billing/locale/fr/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-12-08 15:31+0000\n"
+"POT-Creation-Date: 2016-12-13 20:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: PascalPriori <pascal.priori@savoirfairelinux.com>, 2016\n"
 "Language-Team: French (https://www.transifex.com/savoirfairelinux/"
@@ -23,7 +23,7 @@ msgstr ""
 msgid "total_amount"
 msgstr "total_amount"
 
-#: billing/models.py:123
+#: billing/models.py:127
 msgid "Search by name"
 msgstr "Recherche par nom"
 
@@ -65,7 +65,7 @@ msgid "Order\\"
 msgstr ""
 
 #: billing/templates/billing/add.html:63
-#: billing/templates/billing/view.html:24
+#: billing/templates/billing/partials/summary.html:5
 #: billing/templates/billing/view_orders.html:47
 msgid "Client"
 msgstr "Client"
@@ -96,7 +96,7 @@ msgstr "Montant"
 
 #: billing/templates/billing/add.html:75
 #: billing/templates/billing/list.html:62
-#: billing/templates/billing/view.html:36
+#: billing/templates/billing/partials/summary.html:17
 #: billing/templates/billing/view_orders.html:59
 msgid "Actions"
 msgstr "Actions"
@@ -183,70 +183,73 @@ msgstr ""
 msgid "Revenues"
 msgstr ""
 
+#: billing/templates/billing/partials/summary.html:6
+#: billing/templates/billing/view_orders.html:48
+msgid "Quickly access the client file."
+msgstr ""
+
+#: billing/templates/billing/partials/summary.html:8
+msgid "Total Orders"
+msgstr ""
+
+#: billing/templates/billing/partials/summary.html:9
+msgid "Number of orders in total in this billing period."
+msgstr ""
+
+#: billing/templates/billing/partials/summary.html:11
+msgid "Total Main Dishes"
+msgstr ""
+
+#: billing/templates/billing/partials/summary.html:12
+msgid "Number of main dishes in total in this billing period."
+msgstr ""
+
+#: billing/templates/billing/partials/summary.html:14
+#, fuzzy
+#| msgid "total_amount"
+msgid "Total Amount"
+msgstr "total_amount"
+
+#: billing/templates/billing/partials/summary.html:15
+msgid "Total amount in this billing period."
+msgstr ""
+
+#: billing/templates/billing/partials/summary.html:22
+#: billing/templates/billing/view_orders.html:77
+msgid "Total"
+msgstr ""
+
+#: billing/templates/billing/partials/summary.html:27
+#: billing/templates/billing/partials/summary.html:49
+#, fuzzy
+#| msgid "order id"
+msgid "View Orders"
+msgstr "# de commande"
+
+#: billing/templates/billing/partials/summary.html:39
+msgid "Regular"
+msgstr ""
+
+#: billing/templates/billing/partials/summary.html:41
+msgid "and"
+msgstr ""
+
+#: billing/templates/billing/partials/summary.html:43
+msgid "Large"
+msgstr ""
+
+#: billing/templates/billing/print_summary.html:7
+#: billing/templates/billing/print_summary.html:23
 #: billing/templates/billing/view.html:5 billing/templates/billing/view.html:9
 #, fuzzy
 #| msgid "Billing"
 msgid "Billing Summary"
 msgstr "Facturation"
 
+#: billing/templates/billing/print_summary.html:25
 #: billing/templates/billing/view.html:19
 #: billing/templates/billing/view_orders.html:37
 msgid "Print"
-msgstr ""
-
-#: billing/templates/billing/view.html:25
-#: billing/templates/billing/view_orders.html:48
-msgid "Quickly access the client file."
-msgstr ""
-
-#: billing/templates/billing/view.html:27
-msgid "Total Orders"
-msgstr ""
-
-#: billing/templates/billing/view.html:28
-msgid "Number of orders in total in this billing period."
-msgstr ""
-
-#: billing/templates/billing/view.html:30
-msgid "Total Main Dishes"
-msgstr ""
-
-#: billing/templates/billing/view.html:31
-msgid "Number of main dishes in total in this billing period."
-msgstr ""
-
-#: billing/templates/billing/view.html:33
-#, fuzzy
-#| msgid "total_amount"
-msgid "Total Amount"
-msgstr "total_amount"
-
-#: billing/templates/billing/view.html:34
-msgid "Total amount in this billing period."
-msgstr ""
-
-#: billing/templates/billing/view.html:46
-msgid "Regular"
-msgstr ""
-
-#: billing/templates/billing/view.html:48
-msgid "and"
-msgstr ""
-
-#: billing/templates/billing/view.html:50
-msgid "Large"
-msgstr ""
-
-#: billing/templates/billing/view.html:56
-#: billing/templates/billing/view.html:66
-#, fuzzy
-#| msgid "order id"
-msgid "View Orders"
-msgstr "# de commande"
-
-#: billing/templates/billing/view.html:63
-#: billing/templates/billing/view_orders.html:77
-msgid "Total"
 msgstr ""
 
 #: billing/templates/billing/view_orders.html:5
@@ -288,11 +291,17 @@ msgstr ""
 msgid "Total amount in $CAD."
 msgstr "total_amount"
 
-#: billing/views.py:59
+#: billing/views.py:61
 #, python-format
 msgid ""
 "The billing with the identifier #%s             has been successfully "
 "created."
+msgstr ""
+
+#: billing/views.py:171
+msgid ""
+"Warning: the order(s) below have not set a \"size\" for main dish and thus "
+"have been excluded in \"Total Main Dishes\" column."
 msgstr ""
 
 #, fuzzy

--- a/src/billing/models.py
+++ b/src/billing/models.py
@@ -1,6 +1,6 @@
 import collections
 from django.db import models
-from django.db.models import Q
+from django.db.models import Q, Sum
 from member.models import Client
 from order.models import Order, Order_item
 from datetime import datetime, date
@@ -107,10 +107,14 @@ class Billing(models.Model):
                 'total_main_dishes': {
                     'R': Order_item.objects.filter(
                         order__in=orders, size='R', component_group='main_dish'
-                    ).count(),
+                    ).aggregate(
+                        total_regular=Sum('total_quantity')
+                    )['total_regular'],
                     'L': Order_item.objects.filter(
                         order__in=orders, size='L', component_group='main_dish'
-                    ).count(),
+                    ).aggregate(
+                        total_large=Sum('total_quantity')
+                    )['total_large']
                 },
                 'total_amount': sum(map(lambda o: o.price, orders))
             }

--- a/src/billing/models.py
+++ b/src/billing/models.py
@@ -109,12 +109,12 @@ class Billing(models.Model):
                         order__in=orders, size='R', component_group='main_dish'
                     ).aggregate(
                         total_regular=Sum('total_quantity')
-                    )['total_regular'],
+                    )['total_regular'] or 0,
                     'L': Order_item.objects.filter(
                         order__in=orders, size='L', component_group='main_dish'
                     ).aggregate(
                         total_large=Sum('total_quantity')
-                    )['total_large']
+                    )['total_large'] or 0
                 },
                 'total_amount': sum(map(lambda o: o.price, orders))
             }

--- a/src/billing/templates/billing/partials/summary.html
+++ b/src/billing/templates/billing/partials/summary.html
@@ -1,0 +1,54 @@
+{% load i18n %}
+<table class="ui very basic compact celled table">
+  <thead>
+    <tr>
+      <th>{% trans 'Client' %}
+        <i class="help-text question grey icon link no-print" data-content="{% trans 'Quickly access the client file.' %}"></i>
+      </th>
+      <th>{% trans 'Total Orders' %}
+        <i class="help-text question grey icon link no-print" data-content="{% trans 'Number of orders in total in this billing period.' %}"></i>
+      </th>
+      <th>{% trans 'Total Main Dishes' %}
+        <i class="help-text question grey icon link no-print" data-content="{% trans 'Number of main dishes in total in this billing period.' %}"></i>
+      </th>
+      <th>{% trans 'Total Amount' %}
+        <i class="help-text question grey icon link no-print" data-content="{% trans 'Total amount in this billing period.' %}"></i>
+      </th>
+      <th class="no-print">{% trans 'Actions' %}</th>
+    </tr>
+  </thead>
+  <tfoot>
+    <tr>
+      <th>{% trans "Total" %}</th>
+      <th>{{ billing_total.orders }}</th>
+      <th>{{ billing_total.main_dishes }}</th>
+      <th class="left aligned">${{ billing_total.amount }}</th>
+      <th class="no-print">
+        <a class="ui icon button"  href="{% url 'billing:view_orders' pk=billing.id %}">{% trans 'View Orders' %}</a>
+      </th>
+    </tr>
+  </tfoot>
+  <tbody>
+    {% for client, client_summary in billing_summary %}
+    <tr>
+      <td><a href="{% url 'member:client_information' pk=client.id %}">{{ client.member.lastname|upper }}, {{ client.member.firstname }}</a></td>
+      <td>{{client_summary.total_orders}}</td>
+      <td>
+        {% with client_summary.total_main_dishes as tmd %}
+        {% if tmd.R > 0 %}
+        {{ tmd.R }} {% trans 'Regular' %}
+        {% endif %}
+        {% if tmd.R > 0 and tmd.L > 0 %}{% trans 'and' %}{% endif %}
+        {% if tmd.L > 0 %}
+        {{ tmd.L }} {% trans 'Large' %}
+        {% endif %}
+        {% endwith %}
+      </td>
+      <td class="">${{client_summary.total_amount}}</td>
+      <td class="no-print">
+        <a class="ui icon button"  href="{% url 'billing:view_orders' pk=billing.id %}?client={{ client.id }}">{% trans 'View Orders' %}</a>
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>

--- a/src/billing/templates/billing/print_summary.html
+++ b/src/billing/templates/billing/print_summary.html
@@ -9,53 +9,20 @@
       table {width: 100%;border-collapse:collapse}
       table th {text-align:left}
       table tr {border-bottom: 1px solid black}
+      a[href] {color:inherit;text-decoration:none}
+      .no-print {display:none!important;visilibity:hidden!important}
       @media only screen {
         body {max-width:1024px}  /* for display */
       }
       @media only print {
-        .no-print {display:none!important;visilibity:hidden!important}
+        .no-print-when-print {display:none!important;visilibity:hidden!important}
       }
     </style>
   </head>
   <body>
     <h1 class="ui header">{% trans "Billing Summary" %}</h1>
     <h3>{{billing.billing_period|date:"F Y"}}</h3>
-    <button onclick="javascript:window.print()" class="no-print">{% trans 'Print' %}</button>
-    <table>
-      <thead>
-        <tr>
-          <th>{% trans 'Client' %}</th>
-          <th>{% trans 'Total Orders' %}</th>
-          <th>{% trans 'Total Main Dishes' %}</th>
-          <th>{% trans 'Total Amount' %}</th>
-        </tr>
-      </thead>
-      <tfoot>
-        <tr>
-          <th colspan="3">{% trans "Total" %}</th>
-          <th>${{ billing.total_amount }}</th>
-        </tr>
-      </tfoot>
-      <tbody>
-        {% for client, client_summary in billing_summary %}
-        <tr>
-          <td>{{client}}</td>
-          <td>{{client_summary.total_orders}}</td>
-          <td>
-            {% with client_summary.total_main_dishes as tmd %}
-            {% if tmd.R > 0 %}
-            {{ tmd.R }} {% trans 'Regular' %}
-            {% endif %}
-            {% if tmd.R > 0 and tmd.L > 0 %}{% trans 'and' %}{% endif %}
-            {% if tmd.L > 0 %}
-            {{ tmd.L }} {% trans 'Large' %}
-            {% endif %}
-            {% endwith %}
-          </td>
-          <td>${{client_summary.total_amount}}</td>
-        </tr>
-        {% endfor %}
-      </tbody>
-    </table>
+    <button onclick="javascript:window.print()" class="no-print-when-print">{% trans 'Print' %}</button>
+    {% include 'billing/partials/summary.html' %}
   </body>
 </html>

--- a/src/billing/templates/billing/view.html
+++ b/src/billing/templates/billing/view.html
@@ -19,55 +19,6 @@
     <a href="?print=yes" target="_blank" class="ui labeled icon right big button"><i class="print icon"></i>{% trans 'Print' %}</a>
 </div>
 
-<table class="ui very basic compact celled table">
-  <thead>
-    <tr>
-      <th class="">{% trans 'Client' %}
-        <i class="help-text question grey icon link no-print" data-content="{% trans 'Quickly access the client file.' %}"></i>
-      </th>
-      <th class="">{% trans 'Total Orders' %}
-        <i class="help-text question grey icon link no-print" data-content="{% trans 'Number of orders in total in this billing period.' %}"></i>
-      </th>
-      <th class="">{% trans 'Total Main Dishes' %}
-        <i class="help-text question grey icon link no-print" data-content="{% trans 'Number of main dishes in total in this billing period.' %}"></i>
-      </th>
-      <th class="">{% trans 'Total Amount' %}
-        <i class="help-text question grey icon link no-print" data-content="{% trans 'Total amount in this billing period.' %}"></i>
-      </th>
-      <th class="no-print">{% trans 'Actions' %}</th>
-    </tr>
-  </thead>
-  <tfoot>
-    <tr>
-      <th colspan="3">{% trans "Total" %}</th>
-      <th class="left aligned"><i class="dollar icon"></i>{{ billing.total_amount }}</th>
-      <th class="no-print">
-        <a class="ui icon button"  href="{% url 'billing:view_orders' pk=billing.id %}">{% trans 'View Orders' %}</a>
-      </th>
-    </tr>
-  </tfoot>
-  <tbody>
-    {% for client, client_summary in billing_summary %}
-    <tr>
-      <td><a href="{% url 'member:client_information' pk=client.id %}">{{client}}</a></td>
-      <td>{{client_summary.total_orders}}</td>
-      <td>
-        {% with client_summary.total_main_dishes as tmd %}
-        {% if tmd.R > 0 %}
-        {{ tmd.R }} {% trans 'Regular' %}
-        {% endif %}
-        {% if tmd.R > 0 and tmd.L > 0 %}{% trans 'and' %}{% endif %}
-        {% if tmd.L > 0 %}
-        {{ tmd.L }} {% trans 'Large' %}
-        {% endif %}
-        {% endwith %}
-      </td>
-      <td class=""><i class="dollar icon"></i>{{client_summary.total_amount}}</td>
-      <td class="no-print">
-        <a class="ui icon button"  href="{% url 'billing:view_orders' pk=billing.id %}?client={{ client.id }}">{% trans 'View Orders' %}</a>
-      </td>
-    </tr>
-    {% endfor %}
-  </tbody>
-</table>
+{% include 'billing/partials/summary.html' %}
+
 {% endblock %}

--- a/src/billing/views.py
+++ b/src/billing/views.py
@@ -123,7 +123,21 @@ class BillingSummaryView(generic.DetailView):
 
         # generate a summary
         billing = self.object
-        context['billing_summary'] = billing.summary.items()
+        context['billing_summary'] = list(billing.summary.items())
+        # sort by client lastname
+        context['billing_summary'].sort(
+            key=lambda tup: (tup[0].member.lastname, tup[0].member.firstname)
+        )
+        # tfoot
+        context['billing_total'] = {
+            'orders': billing.orders.all().count(),
+            'main_dishes': sum(map(
+                lambda t: t[1]['total_main_dishes']['R'] +
+                t[1]['total_main_dishes']['L'],
+                context['billing_summary']
+            )),
+            'amount': billing.total_amount
+        }
 
         # Throw a warning if there's any main_dish order with size=None.
         q = Order_item.objects.filter(

--- a/src/sous-chef/templates/base.html
+++ b/src/sous-chef/templates/base.html
@@ -39,7 +39,7 @@
                 {% for message in messages %}
                 <div class="ui {{ message.tags }} message sixteen wide column">
                     <i class="close icon"></i>
-                    <div class="center aligned header">{{ message }}</div>
+                    <div class="center aligned header">{{ message|safe }}</div>
                 </div>
                 {% endfor %}
                 {%block message%}{%endblock%}


### PR DESCRIPTION
## Fixes #562 by lingxiaoyang

### Changes proposed in this pull request:

* Count the main dish quantity when calculating the total main dishes in billing summary.

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

1. Create an order with 2 or more main dishes.
2. Add it to a billing.
3. View billing summary. See if the count is correct.

### Deployment notes and migration

none

### New translatable strings

- [x] included

### Additional notes

Fixed example: Louise now has ordered 2 main dishes with $18.
![image](https://cloud.githubusercontent.com/assets/8630726/21064587/8d5a6100-be29-11e6-90ee-001589f254d0.png)

