### PR TITLE
Fixed #532: ui.dropdown matches full text

### DIFF
--- a/src/frontend/js/global.js
+++ b/src/frontend/js/global.js
@@ -14,7 +14,10 @@ $(function() {
     });
 
     $('.ui.accordion').accordion();
-    $('.ui.dropdown').dropdown({transition: 'drop'});
+    $('.ui.dropdown').dropdown({
+        transition: 'drop',
+        fullTextSearch: 'exact'
+    });
 
     $('.ui.calendar').calendar({
         type: 'date',


### PR DESCRIPTION
## Fixes #532 by lingxiaoyang

### Changes proposed in this pull request:

* Pass `{fullTextSearch: 'exact'}` to ui.dropdowns by default, to enable full text matching (not only from beginning)

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Kitchen count:
![capture du 2016-12-09 16-16-26](https://cloud.githubusercontent.com/assets/8630726/21064845/3e01bdb8-be2b-11e6-9de4-450c2158fc8a.png)

Add a note:
![capture du 2016-12-09 16-16-50](https://cloud.githubusercontent.com/assets/8630726/21064846/3e03dad0-be2b-11e6-8e4c-9e0b2b46664b.png)


### Deployment notes and migration

none

### New translatable strings

none

### Additional notes

none
