### PR TITLE
Fixed #557: semantic UI in list filters

### DIFF
--- a/src/member/templates/client/partials/filters.html
+++ b/src/member/templates/client/partials/filters.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-
+{% load member_extras %}
 <form action="" method="get" class="ui form">
 
     <div class="inline fields">
@@ -15,19 +15,19 @@
         <div class="field">
             <label>{% trans 'Route' %}</label>
             <div class="field">
-                {{ filter.form.route }}
+                {{ filter.form.route|alter_field_class:'ui dropdown' }}
             </div>
         </div>
         <div class="field">
             <label>{% trans 'Status' %}</label>
             <div class="field">
-                {{ filter.form.status }}
+                {{ filter.form.status|alter_field_class:'ui dropdown' }}
             </div>
         </div>
         <div class="field">
             <label>{% trans 'Delivery' %}</label>
             <div class="field">
-                {{ filter.form.delivery_type }}
+                {{ filter.form.delivery_type|alter_field_class:'ui dropdown' }}
             </div>
         </div>
         <input id="id_display" name="display" type="text" value="{{display}}" style="display:none">

--- a/src/member/templatetags/member_extras.py
+++ b/src/member/templatetags/member_extras.py
@@ -46,3 +46,8 @@ def readable_prefs(value):
 @register.filter
 def get_item(o, key):
     return o[key]
+
+
+@register.filter(name='alter_field_class')
+def alter_field_class(field, css):
+    return field.as_widget(attrs={"class": css})

--- a/src/note/templates/notes_list.html
+++ b/src/note/templates/notes_list.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 <!-- Load internationalisation utils-->
 {% load i18n %}
-
+{% load member_extras %}
 {% block title %}{% trans "Staff Notes" %}{% endblock %}
 
 {% block content %}
@@ -42,13 +42,13 @@
           <div class="field">
             <label>{% trans "Priority" %}</label>
             <div class="field">
-              {{ filter.form.priority }}
+              {{ filter.form.priority|alter_field_class:'ui dropdown' }}
             </div>
           </div>
           <div class="field">
             <label>{% trans "Is read" %}</label>
             <div class="field">
-              {{ filter.form.is_read }}
+              {{ filter.form.is_read|alter_field_class:'ui dropdown' }}
             </div>
           </div>
         </div>

--- a/src/order/templates/order/partials/filters.html
+++ b/src/order/templates/order/partials/filters.html
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% load member_extras %}
 
 <form action="" method="get" class="ui form">
 
@@ -15,7 +16,7 @@
         <div class="field">
             <label>{% trans 'Status' %}</label>
             <div class="field">
-                {{ filter.form.status }}
+                {{ filter.form.status|alter_field_class:'ui dropdown' }}
             </div>
         </div>
         <div class="field">


### PR DESCRIPTION
## Fixes #557 by lingxiaoyanag

### Changes proposed in this pull request:

* New templatetag alter_field_class: allow set form field class names in Django template
* Fix client/note/order list filters.

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

http://localhost:8000/member/list/
http://localhost:8000/order/list/
http://localhost:8000/note/

### Deployment notes and migration
none

### New translatable strings
none

### Additional notes

none

