### PR TITLE
Fixed #559

### DIFF
--- a/src/delivery/views.py
+++ b/src/delivery/views.py
@@ -918,5 +918,6 @@ def refreshOrders(request):
             datetime.datetime.now().strftime('%m %d %Y %H:%M')),
         action_flag=ADDITION,
     )
+    orders.sort(key=lambda o: (o.client.route.pk, o.pk))
     context = {'orders': orders}
     return render(request, 'partials/generated_orders.html', context)

--- a/src/delivery/views.py
+++ b/src/delivery/views.py
@@ -50,7 +50,9 @@ class Orderlist(LoginRequiredMixin, generic.ListView):
     context_object_name = 'orders'
 
     def get_queryset(self):
-        queryset = Order.objects.get_shippable_orders()
+        queryset = Order.objects.get_shippable_orders().order_by(
+            'client__route__pk', 'pk'
+        )
         return queryset
 
     def get_context_data(self, **kwargs):

--- a/src/order/models.py
+++ b/src/order/models.py
@@ -75,9 +75,7 @@ class OrderManager(models.Manager):
         return self.get_queryset().filter(
             delivery_date=delivery_date,
             status=ORDER_STATUS_ORDERED,
-            client__status=Client.ACTIVE).order_by(
-                'client__route__pk', 'pk'
-            )
+            client__status=Client.ACTIVE)
 
     def get_shippable_orders_by_route(self, route_id):
         """

--- a/src/order/models.py
+++ b/src/order/models.py
@@ -75,7 +75,9 @@ class OrderManager(models.Manager):
         return self.get_queryset().filter(
             delivery_date=delivery_date,
             status=ORDER_STATUS_ORDERED,
-            client__status=Client.ACTIVE)
+            client__status=Client.ACTIVE).order_by(
+                'client__route__pk', 'pk'
+            )
 
     def get_shippable_orders_by_route(self, route_id):
         """


### PR DESCRIPTION
## Fixes #559 by lingxiaoyang

### Changes proposed in this pull request:

* In kitchen count, order the "orders" by route then order_id. In both page load and refresh ajax view.

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Go to
http://localhost:8000/delivery/order/
The orders should be properly ordered.

Then click on Generate Orders - the new list should have the same order.

### Deployment notes and migration

none

### New translatable strings

none

### Additional notes

none
