### PR TITLE
fix530-531a Kitchen count report Rev 0 and Labels Rev 1

### DIFF
--- a/src/delivery/templates/kitchen_count.html
+++ b/src/delivery/templates/kitchen_count.html
@@ -58,27 +58,31 @@
 <table class="ui very compact celled structured table">
   <thead>
    <tr class="top center aligned">
-    <th class="">{% trans 'Clashing' %} - {% trans 'Ingredients' %}</th>
+    <th class="">{% trans 'Clashing ingredients' %}</th>
     <th class="">{% trans 'Qty' %} - {% trans 'Reg' %}</th>
     <th class="">{% trans 'Qty' %} - {% trans 'Lge' %}</th>
     <th class="">{% trans 'Client' %}</th>
-    <th class="">{% trans 'Preparation' %}</th>
     <th class="">{% trans 'Restrictions' %}</th>
    </tr>
   </thead>
   <tbody>
     {% for obj in meal_lines %}
       <tr{% if obj.client == "" and obj.ingr_clash == "" %} class="active"{% endif %}>
-        {% if not obj.span %}
-              <td><strong>{{obj.ingr_clash}}</strong></td>
+        {% if obj.span == "1" %}
+            <td><strong>{{obj.ingr_clash}}</strong></td>
         {% elif obj.span != "-1" %}
-              <th rowspan={{obj.span}}>{% firstof obj.ingr_clash "&nbsp;" %}</th>
+              <td rowspan={{obj.span}}>{{obj.ingr_clash}}</td>
         {% endif %}
-        <td class="center aligned">{% firstof obj.rqty "&nbsp;" %}</td>
-        <td class="center aligned">{% firstof obj.lqty "&nbsp;" %}</td>
-        <td>{% firstof obj.client "&nbsp;" %}</td>
-        <td>{% firstof obj.preparation "&nbsp;" %}</td>
-        <td>{{obj.rest_ingr}}{% if obj.rest_ingr %} ; {% endif %} <strong>{% firstof obj.rest_item "&nbsp;" %}</strong></td>
+        {% if obj.client == "SUBTOTAL" %}
+            <td class="center aligned"><strong>{{obj.rqty}}</strong></td>
+            <td class="center aligned"><strong>{{obj.lqty}}</strong></td>
+            <td><strong>{{obj.client}}</strong></td>
+        {% else %}
+            <td class="center aligned">{{obj.rqty}}</td>
+            <td class="center aligned">{{obj.lqty}}</td>
+            <td>{{obj.client}}</td>
+        {% endif %}
+        <td>{{obj.rest_ingr}}{% if obj.rest_ingr %} ; {% endif %} <strong>{{obj.rest_item}}</strong></td>
       </tr>
     {% endfor %}
   </tbody>

--- a/src/delivery/tests.py
+++ b/src/delivery/tests.py
@@ -117,7 +117,8 @@ class ChooseDayMainDishIngredientsTestCase(SousChefTestMixin, TestCase):
         req['_next'] = 'Next: Print Kitchen Count'
         req['maindish'] = str(maindish.id)
         req['ingredients'] = ing_ids
-        req['sides_ingredients'] = [Ingredient.objects.all().first().id]
+        req['sides_ingredients'] = [
+            Ingredient.objects.filter(name='zucchini').first().id]
         response = self.client.post(reverse_lazy('delivery:meal'), req)
         response = self.client.get(reverse_lazy('delivery:kitchen_count'))
         self.assertTrue(b'Ginger pork' in response.content)
@@ -133,7 +134,8 @@ class ChooseDayMainDishIngredientsTestCase(SousChefTestMixin, TestCase):
         req['_next'] = 'Next: Print Kitchen Count'
         req['maindish'] = str(maindish.id)
         req['ingredients'] = ing_ids
-        req['sides_ingredients'] = [Ingredient.objects.all().first().id]
+        req['sides_ingredients'] = [
+            Ingredient.objects.filter(name='Onions').first().id]
         response = self.client.post(reverse_lazy('delivery:meal'), req)
         response = self.client.get(reverse_lazy('delivery:kitchen_count'))
         self.assertTrue(b'Ginger pork' in response.content)

--- a/src/delivery/views.py
+++ b/src/delivery/views.py
@@ -642,12 +642,20 @@ def kcr_make_labels(kitchen_list, main_dish_name, main_dish_ingredients):
                     width=65,
                     break_long_words=False, break_on_hyphens=False))
         other_restrictions = []
-        other_restrictions.extend(
-            sorted(list(set(kititm.avoid_ingredients) -
-                        set(kititm.sides_clashes))))
-        other_restrictions.extend(
-            sorted(list(set(kititm.restricted_items) -
-                        set(kititm.sides_clashes))))
+        if kititm.sides_clashes:
+            other_restrictions.extend(
+                sorted(list(set(kititm.avoid_ingredients) -
+                            set(kititm.sides_clashes))))
+            other_restrictions.extend(
+                sorted(list(set(kititm.restricted_items) -
+                            set(kititm.sides_clashes))))
+        else:
+            other_restrictions.extend(
+                sorted(list(set(kititm.avoid_ingredients) -
+                            set(kititm.incompatible_ingredients))))
+            other_restrictions.extend(
+                sorted(list(set(kititm.restricted_items) -
+                            set(kititm.incompatible_ingredients))))
         if other_restrictions:
             meal_label = meal_label._replace(
                 other_restrictions=textwrap.wrap(

--- a/src/delivery/views.py
+++ b/src/delivery/views.py
@@ -22,7 +22,8 @@ from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin
 
 import labels  # package pylabels
-from reportlab.graphics import shapes
+
+from reportlab.graphics import shapes as rl_shapes
 
 from delivery.models import Delivery
 from meal.models import (
@@ -286,10 +287,9 @@ meal_line_fields = [               # Special Meal Line on Kitchen Count.
     'rqty', '',     # String : Quantity of regular size main dishes
     'lqty', '',     # String : Quantity of large size main dishes
     'ingr_clash', '',     # String : Ingredients that clash
-    'preparation', '',     # String : Meal preparations
     'rest_ingr', '',     # String : Other ingredients to avoid
     'rest_item', '',     # String : Restricted items
-    'span', None]   # Number of lines to "rowspan" in table
+    'span', '1']   # Number of lines to "rowspan" in table
 MealLine = collections.namedtuple(
     'MealLine', meal_line_fields[0::2])
 
@@ -312,11 +312,12 @@ def meal_line(kititm):
               if kititm.meal_size == SIZE_CHOICES_REGULAR else ''),
         lqty=(str(kititm.meal_qty)
               if kititm.meal_size == SIZE_CHOICES_LARGE else ''),
-        ingr_clash=', '.join(kititm.incompatible_ingredients),
-        preparation=', '.join(kititm.preparation),
-        rest_ingr=', '.join(kititm.other_ingredients),
+        ingr_clash='',
+        rest_ingr=', '.join(
+            sorted(list(set(kititm.avoid_ingredients) -
+                        set(kititm.incompatible_ingredients)))),
         rest_item=', '.join(kititm.restricted_items),
-        span=None)
+        span='1')
 
 
 def kcr_cumulate(regular, large, meal):
@@ -344,8 +345,8 @@ def kcr_make_lines(kitchen_list, date):
     """Generate the sections and lines for the kitchen count report.
 
     Count all the dishes that have to be prepared and identify all the
-    special client requirements such as disliked ingredients,
-    restrictions and necessary food preparation.
+    special client requirements such as disliked ingredients and
+    restrictions.
 
     Args: kitchen_list : A dictionary of KitchenItem objects (see
               order/models) which contain detailed information about
@@ -369,11 +370,16 @@ def kcr_make_lines(kitchen_list, date):
                     component_group=component_group,
                     rqty=0,
                     lqty=0,
-                    name=meal_component.name,
-                    ingredients=", ".join(
-                        [ing.name for ing in
-                         Component.get_day_ingredients(
-                             meal_component.id, date)])))
+                    name='',
+                    ingredients=''))
+            if component_group == COMPONENT_GROUP_CHOICES_MAIN_DISH:
+                component_lines[component_group] = \
+                    component_lines[component_group]._replace(
+                        name=meal_component.name,
+                        ingredients=", ".join(
+                            [ing.name for ing in
+                             Component.get_day_ingredients(
+                                 meal_component.id, date)]))
             if (component_group == COMPONENT_GROUP_CHOICES_MAIN_DISH and
                     item.meal_size == SIZE_CHOICES_LARGE):
                 component_lines[component_group] = \
@@ -403,30 +409,37 @@ def kcr_make_lines(kitchen_list, date):
 
     meal_lines = []
     rtotal, ltotal = (0, 0)
-    # part 1 Ingredients clashes (and other columns)
+    # Ingredients clashes (and other columns)
     rsubtotal, lsubtotal = (0, 0)
     clients = iter(sorted(
         [(ke, val) for ke, val in kitchen_list.items() if
          val.incompatible_ingredients],
         key=lambda x: x[1].incompatible_ingredients))
+
     # first line of a combination of ingredients
-    line_start = len(meal_lines)
-    k, v = next(clients, (0, 0))
+    line_start = 0
+    rsubtotal, lsubtotal = (0, 0)
+    k, v = next(clients, (0, 0))  # has end sentinel
     while k > 0:
+        if rsubtotal == 0 and lsubtotal == 0:
+            # add line for subtotal at top of combination
+            meal_lines.append(MealLine(*meal_line_fields[1::2]))
         combination = v.incompatible_ingredients
         meal_lines.append(meal_line(v))
         rsubtotal, lsubtotal = kcr_cumulate(rsubtotal, lsubtotal, v)
         k, v = next(clients, (0, 0))
         if k == 0 or combination != v.incompatible_ingredients:
-            meal_lines.append(MealLine(*meal_line_fields[1::2])._replace(
-                client='SUBTOTAL', rqty=str(rsubtotal), lqty=str(lsubtotal)))
-            rtotal, ltotal = (rtotal + rsubtotal, ltotal + lsubtotal)
-            rsubtotal, lsubtotal = (0, 0)
             # last line of this combination of ingredients
             line_end = len(meal_lines)
             # set rowspan to total number of lines for this combination
             meal_lines[line_start] = meal_lines[line_start]._replace(
+                client='SUBTOTAL',
+                rqty=str(rsubtotal),
+                lqty=str(lsubtotal),
+                ingr_clash=', '.join(combination),
                 span=str(line_end - line_start))
+            rtotal, ltotal = (rtotal + rsubtotal, ltotal + lsubtotal)
+            rsubtotal, lsubtotal = (0, 0)
             # hide ingredients for lines following the first
             for j in range(line_start + 1, line_end):
                 meal_lines[j] = meal_lines[j]._replace(span='-1')
@@ -436,22 +449,6 @@ def kcr_make_lines(kitchen_list, date):
             line_start = len(meal_lines)
     # END WHILE
 
-    # part 2 No clashes but preparation (and other columns)
-    rsubtotal, lsubtotal = (0, 0)
-    for v in sorted(
-            [val for val in kitchen_list.values() if
-             (not val.incompatible_ingredients and
-              val.preparation)],
-            key=lambda x: x.lastname + x.firstname):
-        meal_lines.append(meal_line(v))
-        rsubtotal, lsubtotal = kcr_cumulate(rsubtotal, lsubtotal, v)
-        # Add a blank line as separator
-        meal_lines.append(MealLine(*meal_line_fields[1::2]))
-    # END FOR
-    if rsubtotal or lsubtotal:
-        meal_lines.append(MealLine(*meal_line_fields[1::2])._replace(
-            client='SUBTOTAL', rqty=str(rsubtotal), lqty=str(lsubtotal)))
-    rtotal, ltotal = (rtotal + rsubtotal, ltotal + lsubtotal)
     meal_lines.append(MealLine(*meal_line_fields[1::2])._replace(
         rqty=str(rtotal), lqty=str(ltotal), ingr_clash='TOTAL SPECIALS'))
 
@@ -461,17 +458,17 @@ def kcr_make_lines(kitchen_list, date):
 meal_label_fields = [                         # Contents for Meal Labels.
     # field name, default value
     'sortkey', '',          # key for sorting
-    'type', 2,              # Number : section for sorting
     'route', '',            # String : Route name
     'name', '',             # String : Last + First abbreviated
     #                         String : Delivery date
     'date', "{}".format(datetime.date.today().strftime("%a, %b-%d")),
     'size', '',             # String : Regular or Large
-    'box', 1,               # Number : serving number
-    'qty', 1,               # Number : quantity of servings
     'main_dish_name', '',   # String
-    'main_dish_ingredient_lines', [],     # List of strings
-    'requirement_lines', []]     # List of strings
+    'dish_clashes', [],   # List of strings
+    'preparations', [],   # List of strings
+    'sides_clashes', [],    # List of strings
+    'other_restrictions', [],   # List of strings
+    'ingredients', []]  # List of strings
 MealLabel = collections.namedtuple(
     'MealLabel', meal_label_fields[0::2])
 
@@ -488,48 +485,77 @@ def draw_label(label, width, height, data):
         data : A MealLabel namedtuple.
     """
     # dimensions are in font points
+    # Line 1
     vertic_pos = height * 0.85
     horiz_margin = 3
     if data.name:
-        label.add(shapes.String(
+        label.add(rl_shapes.String(
             horiz_margin, vertic_pos, data.name,
             fontName="Helvetica-Bold", fontSize=12))
+    if data.route:
+        label.add(rl_shapes.String(
+            width / 2.0, vertic_pos, data.route,
+            fontName="Helvetica-Oblique", fontSize=10, textAnchor="middle"))
     if data.date:
-        label.add(shapes.String(
+        label.add(rl_shapes.String(
             width - horiz_margin, vertic_pos, data.date,
             fontName="Helvetica", fontSize=10, textAnchor="end"))
-    vertic_pos -= 12
-    if data.size:
-        label.add(shapes.String(
-            horiz_margin, vertic_pos, data.size,
-            fontName="Helvetica", fontSize=10))
-    if data.qty > 1:
-        label.add(shapes.String(
-            width * 0.5, vertic_pos,
-            "(" + str(data.box) + " of " + str(data.qty) + ")",
-            fontName="Helvetica", fontSize=10))
-    if data.route:
-        label.add(shapes.String(
-            width - horiz_margin - 1, vertic_pos, data.route,
-            fontName="Helvetica-Oblique", fontSize=8, textAnchor="end"))
-    vertic_pos -= 10
+    # Line 2
+    vertic_pos -= 14
     if data.main_dish_name:
-        label.add(shapes.String(
+        label.add(rl_shapes.String(
             horiz_margin, vertic_pos, data.main_dish_name,
             fontName="Helvetica-Bold", fontSize=10))
+    if data.size:
+        label.add(rl_shapes.String(
+            width - horiz_margin, vertic_pos, data.size,
+            fontName="Helvetica", fontSize=10, textAnchor="end"))
+    # Line(s) 3
     vertic_pos -= 12
-    if data.requirement_lines:
-        for line in data.requirement_lines:
-            label.add(shapes.String(
+    if data.dish_clashes:
+        for line in data.dish_clashes:
+            if vertic_pos < 0:
+                break
+            label.add(rl_shapes.String(
                 horiz_margin, vertic_pos, line,
                 fontName="Helvetica", fontSize=9))
             vertic_pos -= 10
-    if data.main_dish_ingredient_lines:
-        for line in data.main_dish_ingredient_lines:
-            label.add(shapes.String(
+    # Line(s) 4
+    if data.preparations:
+        for line in data.preparations:
+            if vertic_pos < 0:
+                break
+            label.add(rl_shapes.String(
+                horiz_margin, vertic_pos, line,
+                fontName="Helvetica-Bold", fontSize=9))
+            vertic_pos -= 10
+    # Line(s) 5
+    if data.sides_clashes:
+        for line in data.sides_clashes:
+            if vertic_pos < 0:
+                break
+            label.add(rl_shapes.String(
+                horiz_margin, vertic_pos, line,
+                fontName="Helvetica", fontSize=9))
+            vertic_pos -= 10
+    # Line(s) 6
+    if data.other_restrictions:
+        for line in data.other_restrictions:
+            if vertic_pos < 0:
+                break
+            label.add(rl_shapes.String(
+                horiz_margin, vertic_pos, line,
+                fontName="Helvetica", fontSize=9))
+            vertic_pos -= 10
+    # Line(s) 7
+    if data.ingredients:
+        for line in data.ingredients:
+            if vertic_pos < 0:
+                break
+            label.add(rl_shapes.String(
                 horiz_margin, vertic_pos, line,
                 fontName="Helvetica", fontSize=8))
-            vertic_pos -= 10
+            vertic_pos -= 9
 
 
 def kcr_make_labels(kitchen_list, main_dish_name, main_dish_ingredients):
@@ -546,8 +572,8 @@ def kcr_make_labels(kitchen_list, main_dish_name, main_dish_ingredients):
             order/models) which contain detailed information about
             all the meals that have to be prepared for the day and
             the client requirements and restrictions.
-        main_dish_name : A string being the name of today's main dish.
-        main_dish_ingredient : A string being the comma separated list
+        main_dish_name : A string, the name of today's main dish.
+        main_dish_ingredient : A string, the comma separated list
             of all the ingredients in today's main dish.
 
     Returns:
@@ -581,56 +607,57 @@ def kcr_make_labels(kitchen_list, main_dish_name, main_dish_ingredients):
     meal_labels = []
     for kititm in kitchen_list.values():
         meal_label = MealLabel(*meal_label_fields[1::2])
-        if (kititm.incompatible_ingredients or kititm.preparation or
-                kititm.meal_size == SIZE_CHOICES_LARGE):
-            # Specials
-            #
-            requirements = []
-            requirements.extend(kititm.preparation)
-            #
-            if kititm.incompatible_ingredients:
-                requirements.extend(
-                    ["No " + item for item in kititm.avoid_ingredients])
-                requirements.extend(
-                    ["No " + item for item in kititm.restricted_items])
-                meal_label = meal_label._replace(
-                    main_dish_name='_________________________________________')
-            else:
-                meal_label = meal_label._replace(
-                    main_dish_name=main_dish_name,
-                    main_dish_ingredient_lines=textwrap.wrap(
-                        'INGREDIENTS : {}'.format(main_dish_ingredients),
-                        width=74,
-                        break_long_words=False, break_on_hyphens=False))
-            if kititm.meal_size == SIZE_CHOICES_LARGE:
-                meal_label = meal_label._replace(size='LARGE')
-            if requirements:
-                meal_label = meal_label._replace(
-                    type='1',
-                    main_dish_name='SPECIAL : {}'.format(
-                        meal_label.main_dish_name))
+        meal_label = meal_label._replace(
+            route=kititm.routename,
+            main_dish_name=main_dish_name,
+            name=kititm.lastname + ", " + kititm.firstname[0:2] + ".")
+        if kititm.meal_size == SIZE_CHOICES_LARGE:
+            meal_label = meal_label._replace(size='LARGE')
+        if kititm.incompatible_ingredients:
             meal_label = meal_label._replace(
-                route=kititm.routename,
-                name=kititm.lastname + ", " + kititm.firstname[0:2] + ".",
-                requirement_lines=textwrap.wrap(
-                    ' / '.join(requirements), width=68,
+                main_dish_name='_______________________________________',
+                dish_clashes=textwrap.wrap(
+                    'Special : {}'.format(
+                        ' , '.join(kititm.incompatible_ingredients)),
+                    width=65,
                     break_long_words=False, break_on_hyphens=False))
-            if kititm.meal_qty > 1:
-                for j in range(1, kititm.meal_qty + 1):
-                    meal_label = meal_label._replace(
-                        box=j, qty=kititm.meal_qty)
-                    meal_labels.append(meal_label)
-            else:
-                meal_labels.append(meal_label)
-        else:
-            # Non specials
+        elif not kititm.sides_clashes:
             meal_label = meal_label._replace(
-                type='3',
-                main_dish_name=main_dish_name,
-                main_dish_ingredient_lines=textwrap.wrap(
-                    'INGREDIENTS : {}'.format(main_dish_ingredients), width=74,
+                ingredients=textwrap.wrap(
+                    'Ingredients : {}'.format(main_dish_ingredients),
+                    width=74,
                     break_long_words=False, break_on_hyphens=False))
+        if kititm.preparation:
+            meal_label = meal_label._replace(
+                preparations=textwrap.wrap(
+                    'Preparation= {}'.format(
+                        ' , '.join(kititm.preparation)),
+                    width=65,
+                    break_long_words=False, break_on_hyphens=False))
+        if kititm.sides_clashes:
+            meal_label = meal_label._replace(
+                sides_clashes=textwrap.wrap(
+                    'Sides clashes= {}'.format(
+                        ' , '.join(kititm.sides_clashes)),
+                    width=65,
+                    break_long_words=False, break_on_hyphens=False))
+        other_restrictions = []
+        other_restrictions.extend(
+            sorted(list(set(kititm.avoid_ingredients) -
+                        set(kititm.sides_clashes))))
+        other_restrictions.extend(
+            sorted(list(set(kititm.restricted_items) -
+                        set(kititm.sides_clashes))))
+        if other_restrictions:
+            meal_label = meal_label._replace(
+                other_restrictions=textwrap.wrap(
+                    'Other restrictions= {}'.format(
+                        ' , '.join(other_restrictions)),
+                    width=65,
+                    break_long_words=False, break_on_hyphens=False))
+        for j in range(1, kititm.meal_qty + 1):
             meal_labels.append(meal_label)
+
     # find max lengths of fields to sort on
     routew = 0
     namew = 0
@@ -640,9 +667,9 @@ def kcr_make_labels(kitchen_list, main_dish_name, main_dish_ingredients):
     # generate sorting key
     meal_labels = [
         label._replace(
-            sortkey='{typ}{rou:{rouw}}{nam:{namw}}{box}'.format(
-                typ=label.type, rou=label.route, rouw=routew,
-                nam=label.name, namw=namew, box=label.box))
+            sortkey='{rou:{rouw}}{nam:{namw}}'.format(
+                rou=label.route, rouw=routew,
+                nam=label.name, namw=namew))
         for label in meal_labels]
     # generate labels into PDF
     for label in sorted(meal_labels, key=lambda x: x.sortkey):


### PR DESCRIPTION
## Fixes #530 and #531.

- This includes revision 1 to meal labels requested at SRoulant by JFF and JV on 2016-12-07 and the corrections requested by @manumilou in his review of the first PR.
- This replaces PR #553 which was closed.

### Changes proposed in this pull request:

- delivery/templates/kitchen_count : revise rows and columns layout
- delivery/views : revise kitchen count and labels content
- order/models : revise kitchen count queries and KitchenItem processing

### Status

- [X] Ready

### How to verify this change

- Execute kitchen count steps 1, 2 and 3; view page and click Download labels. Note that the PDF layout of the kitchen count report will be added later as solution for issue #498.
