### PR TITLE
Fix #558 -- Add filters on the review orders page

### DIFF
--- a/src/delivery/filters.py
+++ b/src/delivery/filters.py
@@ -1,0 +1,29 @@
+from functools import reduce
+
+from django.db.models import Q
+from django.utils.translation import ugettext_lazy as _
+import django_filters
+
+from order.models import Order
+
+
+class KitchenCountOrderFilter(django_filters.FilterSet):
+    """ Defines the filters used to filter orders in the Kitchen Count. """
+
+    client_name = django_filters.MethodFilter(
+        action='filter_client', label=_('Search by client name'))
+
+    class Meta:
+        model = Order
+
+    def filter_client(self, queryset, value):
+        """ Filters the orders using client names. """
+        if not value:
+            return queryset
+
+        bits = value.split(' ')
+        queryset = queryset.filter(reduce(
+            lambda q, name: q | Q(client__member__firstname__icontains=name) |
+            Q(client__member__lastname__icontains=name), bits, Q()))
+
+        return queryset

--- a/src/delivery/templates/partials/generated_orders.html
+++ b/src/delivery/templates/partials/generated_orders.html
@@ -2,6 +2,7 @@
 {% load i18n %}
 {% load static %}
 
+<div class="ui segment basic padded">
 <table id="generated-orders" class="ui very basic stripped compact celled table">
   <thead>
     <th class="">{% trans 'Order' %}
@@ -48,3 +49,4 @@
     {% endfor %}
   </tbody>
 </table>
+</div>

--- a/src/delivery/templates/partials/generated_orders.html
+++ b/src/delivery/templates/partials/generated_orders.html
@@ -2,7 +2,6 @@
 {% load i18n %}
 {% load static %}
 
-<div class="ui segment basic padded">
 <table id="generated-orders" class="ui very basic stripped compact celled table">
   <thead>
     <th class="">{% trans 'Order' %}
@@ -49,4 +48,3 @@
     {% endfor %}
   </tbody>
 </table>
-</div>

--- a/src/delivery/templates/review_orders.html
+++ b/src/delivery/templates/review_orders.html
@@ -69,29 +69,32 @@
         {% trans 'Review' %}
     </h4>
 
-
-<form action="" method="get" class="ui form fluid">
-    <div class="inline fields">
-        <div class="field">
-            <label for="{{ filter.form.client_name.auto_id }}">{% trans 'Client name' %}</label>
-            <div class="field">
-                <div class="ui large left icon input">
-                    <i class="users icon"></i>
-                    {{ filter.form.client_name }}
+    <div class="sixteen wide column">
+        <form action="" method="get" class="ui form">
+            <div class="inline fields">
+                <div class="field">
+                    <label for="{{ filter.form.client_name.auto_id }}">{% trans 'Client name' %}</label>
+                    <div class="field">
+                        <div class="ui large left icon input">
+                            <i class="users icon"></i>
+                            {{ filter.form.client_name }}
+                        </div>
+                    </div>
                 </div>
             </div>
-        </div>
+            <div class="field padded">
+                <a href="{% url 'delivery:order' %}" class="ui basic button">{% trans 'Reset' %}</a>
+                <button class="ui yellow button" type="submit">{% trans 'Search' %}</button>
+            </div>
+        </form>
+        {% include 'partials/generated_orders.html' %}
     </div>
-    <div class="field padded">
-        <a href="{% url 'delivery:order' %}" class="ui basic button">{% trans 'Reset' %}</a>
-        <button class="ui yellow button" type="submit">{% trans 'Search' %}</button>
-    </div>
-</form>
-{% include 'partials/generated_orders.html' %}
 
-<a class="ui labeled icon right yellow big button" href="{% url 'delivery:meal' %}">
-    <i class="chevron right icon"></i>{% trans "OK, I'm ready" %}
-</a>
+    <div class="sixteen wide column">
+        <a class="ui labeled icon right yellow big button" href="{% url 'delivery:meal' %}">
+            <i class="chevron right icon"></i>{% trans "OK, I'm ready" %}
+        </a>
+    </div>
 
 </div>
 

--- a/src/delivery/templates/review_orders.html
+++ b/src/delivery/templates/review_orders.html
@@ -69,6 +69,24 @@
         {% trans 'Review' %}
     </h4>
 
+
+<form action="" method="get" class="ui form fluid">
+    <div class="inline fields">
+        <div class="field">
+            <label for="{{ filter.form.client_name.auto_id }}">{% trans 'Client name' %}</label>
+            <div class="field">
+                <div class="ui large left icon input">
+                    <i class="users icon"></i>
+                    {{ filter.form.client_name }}
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="field padded">
+        <a href="{% url 'delivery:order' %}" class="ui basic button">{% trans 'Reset' %}</a>
+        <button class="ui yellow button" type="submit">{% trans 'Search' %}</button>
+    </div>
+</form>
 {% include 'partials/generated_orders.html' %}
 
 <a class="ui labeled icon right yellow big button" href="{% url 'delivery:meal' %}">


### PR DESCRIPTION
## Fixes #558 by ellmetha

### Changes proposed in this pull request:

* Add a new filter class and use it in order to filter the orders in the "Kitchen Count" section

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

* Go to the "Kitchen Count" section and enter a client name in the related form field


