### PR TITLE
Fix #571 -- Allow printing all the route sheets at once

### DIFF
--- a/src/delivery/locale/en/LC_MESSAGES/django.po
+++ b/src/delivery/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-11-22 23:01+0000\n"
+"POT-Creation-Date: 2016-12-13 15:09+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,12 +17,24 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
+#: delivery/filters.py:14
+msgid "Search by client name"
+msgstr ""
+
 #: delivery/forms.py:11
 msgid "Today's main dish:"
 msgstr ""
 
 #: delivery/forms.py:18
-msgid "Select Ingredients:"
+msgid "Select main dish ingredients:"
+msgstr ""
+
+#: delivery/forms.py:26
+msgid "Select sides ingredients:"
+msgstr ""
+
+#: delivery/forms.py:37
+msgid "Please choose some Sides ingredients"
 msgstr ""
 
 #: delivery/models.py:10
@@ -41,16 +53,16 @@ msgstr ""
 msgid "Main dish"
 msgstr ""
 
-#: delivery/templates/ingredients.html:70
+#: delivery/templates/ingredients.html:63
 msgid "Restore recipe"
 msgstr ""
 
-#: delivery/templates/ingredients.html:76
-#: delivery/templates/kitchen_count.html:82 delivery/templates/routes.html:53
+#: delivery/templates/ingredients.html:77
+#: delivery/templates/kitchen_count.html:89 delivery/templates/routes.html:62
 msgid "Back"
 msgstr ""
 
-#: delivery/templates/ingredients.html:77
+#: delivery/templates/ingredients.html:79
 msgid "Next: Print Kitchen Count"
 msgstr ""
 
@@ -63,82 +75,92 @@ msgid "Kitchen Count Report"
 msgstr ""
 
 #: delivery/templates/kitchen_count.html:20
-msgid "Print the Report"
+msgid "Print the kitchen count report"
 msgstr ""
 
-#: delivery/templates/kitchen_count.html:22
-msgid "Download Labels"
+#: delivery/templates/kitchen_count.html:21
+#: delivery/templates/kitchen_count_steps.html:18
+msgid "Kitchen Count"
 msgstr ""
 
 #: delivery/templates/kitchen_count.html:24
-msgid "No Labels Found"
+msgid "Download the labels"
 msgstr ""
 
-#: delivery/templates/kitchen_count.html:32
+#: delivery/templates/kitchen_count.html:25
+#: delivery/templates/kitchen_count.html:29
+msgid "Labels"
+msgstr ""
+
+#: delivery/templates/kitchen_count.html:28
+msgid "No labels available"
+msgstr ""
+
+#: delivery/templates/kitchen_count.html:38
 msgid "Component"
 msgstr ""
 
-#: delivery/templates/kitchen_count.html:33
-#: delivery/templates/kitchen_count.html:34
+#: delivery/templates/kitchen_count.html:39
+#: delivery/templates/kitchen_count.html:40
 msgid "TOTAL"
 msgstr ""
 
-#: delivery/templates/kitchen_count.html:33
-#: delivery/templates/route_sheet.html:22
+#: delivery/templates/kitchen_count.html:39
+#: delivery/templates/route_sheet.html:30
 msgid "Regular"
 msgstr ""
 
-#: delivery/templates/kitchen_count.html:34
-#: delivery/templates/route_sheet.html:23
+#: delivery/templates/kitchen_count.html:40
+#: delivery/templates/route_sheet.html:31
 msgid "Large"
 msgstr ""
 
-#: delivery/templates/kitchen_count.html:35
+#: delivery/templates/kitchen_count.html:41
 msgid "Dish today"
 msgstr ""
 
-#: delivery/templates/kitchen_count.html:36
+#: delivery/templates/kitchen_count.html:42
 msgid "Ingredients today"
 msgstr ""
 
-#: delivery/templates/kitchen_count.html:55
+#: delivery/templates/kitchen_count.html:61
 msgid "Clashing"
 msgstr ""
 
-#: delivery/templates/kitchen_count.html:55
+#: delivery/templates/kitchen_count.html:61
 #: delivery/templates/kitchen_count_steps.html:12
 msgid "Ingredients"
 msgstr ""
 
-#: delivery/templates/kitchen_count.html:56
-#: delivery/templates/kitchen_count.html:57
-#: delivery/templates/route_sheet.html:43
+#: delivery/templates/kitchen_count.html:62
+#: delivery/templates/kitchen_count.html:63
+#: delivery/templates/route_sheet.html:51
 msgid "Qty"
 msgstr ""
 
-#: delivery/templates/kitchen_count.html:56
+#: delivery/templates/kitchen_count.html:62
 msgid "Reg"
 msgstr ""
 
-#: delivery/templates/kitchen_count.html:57
+#: delivery/templates/kitchen_count.html:63
 msgid "Lge"
 msgstr ""
 
-#: delivery/templates/kitchen_count.html:58
-#: delivery/templates/review_orders.html:77
-#: delivery/templates/route_sheet.html:40
+#: delivery/templates/kitchen_count.html:64
+#: delivery/templates/partials/generated_orders.html:10
+#: delivery/templates/route_sheet.html:48
 msgid "Client"
 msgstr ""
 
-#: delivery/templates/kitchen_count.html:59
+#: delivery/templates/kitchen_count.html:65
 msgid "Preparation"
 msgstr ""
 
-#: delivery/templates/kitchen_count.html:60
+#: delivery/templates/kitchen_count.html:66
 msgid "Restrictions"
 msgstr ""
 
-#: delivery/templates/kitchen_count.html:83
+#: delivery/templates/kitchen_count.html:92
 msgid "Next: Organize Routes"
 msgstr ""
 
@@ -153,10 +175,6 @@ msgstr ""
 
 #: delivery/templates/kitchen_count_steps.html:13
 msgid "Pick ingredients for the day."
-msgstr ""
-
-#: delivery/templates/kitchen_count_steps.html:18
-msgid "Kitchen Count"
 msgstr ""
 
 #: delivery/templates/kitchen_count_steps.html:19
@@ -179,26 +197,89 @@ msgstr ""
 msgid "Delivery route"
 msgstr ""
 
-#: delivery/templates/organize_route.html:36 delivery/templates/routes.html:35
+#: delivery/templates/organize_route.html:26
+msgid "Print the map and directions"
+msgstr ""
+
+#: delivery/templates/organize_route.html:27
+msgid "Map and Directions"
+msgstr ""
+
+#: delivery/templates/organize_route.html:42 delivery/templates/routes.html:43
 msgid "Print the route sheet"
 msgstr ""
 
-#: delivery/templates/organize_route.html:37 delivery/templates/routes.html:36
+#: delivery/templates/organize_route.html:43 delivery/templates/routes.html:44
 msgid "Route sheet"
 msgstr ""
 
-#: delivery/templates/organize_route.html:39
-#: delivery/templates/route_sheet.html:77
+#: delivery/templates/organize_route.html:45
+#: delivery/templates/route_sheet.html:85
 msgid "View routes list"
 msgstr ""
 
-#: delivery/templates/organize_route.html:40
-#: delivery/templates/route_sheet.html:78
+#: delivery/templates/organize_route.html:46
+#: delivery/templates/route_sheet.html:86
 msgid "View routes"
 msgstr ""
 
+#: delivery/templates/partials/generated_orders.html:7
+msgid "Order"
+msgstr ""
+
+#: delivery/templates/partials/generated_orders.html:8
+msgid "A unique identifier for the order."
+msgstr ""
+
+#: delivery/templates/partials/generated_orders.html:11
+msgid "Quickly access the client file."
+msgstr ""
+
+#: delivery/templates/partials/generated_orders.html:13
+msgid "Delivery Date"
+msgstr ""
+
+#: delivery/templates/partials/generated_orders.html:14
+msgid "The delivery date planned for the order."
+msgstr ""
+
+#: delivery/templates/partials/generated_orders.html:16
+msgid "Route"
+msgstr ""
+
+#: delivery/templates/partials/generated_orders.html:17
+msgid "The delivery route."
+msgstr ""
+
+#: delivery/templates/partials/generated_orders.html:19
+msgid "Status"
+msgstr ""
+
+#: delivery/templates/partials/generated_orders.html:20
+msgid "Display only Ordered orders."
+msgstr ""
+
+#: delivery/templates/partials/generated_orders.html:22
+msgid "Amount"
+msgstr ""
+
+#: delivery/templates/partials/generated_orders.html:23
+msgid "Total amount in $CAD."
+msgstr ""
+
+#: delivery/templates/partials/generated_orders.html:37
+msgid "Fix geolocalization."
+msgstr ""
+
+#: delivery/templates/partials/generated_orders.html:43
+msgid "Review or change the status of the order."
+msgstr ""
+
+#: delivery/templates/partials/generated_orders.html:44
+msgid "Change the details of the order."
+msgstr ""
+
 #: delivery/templates/review_orders.html:6
-#: delivery/templates/review_orders.html:65
 msgid "Orders"
 msgstr ""
 
@@ -206,50 +287,42 @@ msgstr ""
 msgid "Orders of the day"
 msgstr ""
 
-#: delivery/templates/review_orders.html:74
-msgid "Order"
+#: delivery/templates/review_orders.html:29
+msgid ""
+"Orders of the day include ongoing and episodic clients. Only Ordered orders "
+"from Active clients are included."
 msgstr ""
 
-#: delivery/templates/review_orders.html:75
-#: delivery/templates/review_orders.html:81
-#: delivery/templates/review_orders.html:84
-#: delivery/templates/review_orders.html:90
-msgid "Order\\"
+#: delivery/templates/review_orders.html:55
+msgid "Generate orders"
 msgstr ""
 
-#: delivery/templates/review_orders.html:78
-msgid "Quickly access the client\\"
+#: delivery/templates/review_orders.html:58
+#, python-format
+msgid ""
+"\n"
+"                        <span>%(count)s</span>\n"
+"                        &nbsp;today\n"
+"                    "
 msgstr ""
 
-#: delivery/templates/review_orders.html:80
-msgid "Delivery Date"
+#: delivery/templates/review_orders.html:69
+msgid "Review"
 msgstr ""
 
-#: delivery/templates/review_orders.html:83
-msgid "Route"
+#: delivery/templates/review_orders.html:76
+msgid "Client name"
 msgstr ""
 
 #: delivery/templates/review_orders.html:86
-msgid "Status"
+msgid "Reset"
 msgstr ""
 
 #: delivery/templates/review_orders.html:87
-msgid "Display only Ordered orders."
+msgid "Search"
 msgstr ""
 
-#: delivery/templates/review_orders.html:89
-msgid "Amount"
-msgstr ""
-
-#: delivery/templates/review_orders.html:103
-msgid "View Order"
-msgstr ""
-
-#: delivery/templates/review_orders.html:111
-msgid "orders today"
-msgstr ""
-
-#: delivery/templates/review_orders.html:117
+#: delivery/templates/review_orders.html:95
 msgid "OK, I'm ready"
 msgstr ""
 
@@ -257,27 +330,35 @@ msgstr ""
 msgid "Delivery Route Sheet"
 msgstr ""
 
-#: delivery/templates/route_sheet.html:21
+#: delivery/templates/route_sheet.html:19
+msgid "Print the route sheet."
+msgstr ""
+
+#: delivery/templates/route_sheet.html:20
+msgid "Route Sheet"
+msgstr ""
+
+#: delivery/templates/route_sheet.html:29
 msgid "Dish"
 msgstr ""
 
-#: delivery/templates/route_sheet.html:41
+#: delivery/templates/route_sheet.html:49
 msgid "Note"
 msgstr ""
 
-#: delivery/templates/route_sheet.html:42
+#: delivery/templates/route_sheet.html:50
 msgid "Item"
 msgstr ""
 
-#: delivery/templates/route_sheet.html:53
+#: delivery/templates/route_sheet.html:61
 msgid "Apt"
 msgstr ""
 
-#: delivery/templates/route_sheet.html:74 delivery/templates/routes.html:32
+#: delivery/templates/route_sheet.html:82 delivery/templates/routes.html:40
 msgid "Organize the route"
 msgstr ""
 
-#: delivery/templates/route_sheet.html:75 delivery/templates/routes.html:33
+#: delivery/templates/route_sheet.html:83 delivery/templates/routes.html:41
 msgid "Organize"
 msgstr ""
 
@@ -289,11 +370,19 @@ msgstr ""
 msgid "Delivery routes"
 msgstr ""
 
-#: delivery/templates/routes.html:43
+#: delivery/templates/routes.html:28
+msgid "Print the route sheets"
+msgstr ""
+
+#: delivery/templates/routes.html:29
+msgid "Route Sheets"
+msgstr ""
+
+#: delivery/templates/routes.html:51
 msgid "Cycling map"
 msgstr ""
 
-#: delivery/templates/routes.html:44
+#: delivery/templates/routes.html:52
 msgid "Number of orders on this route"
 msgstr ""
 

--- a/src/delivery/locale/en/LC_MESSAGES/django.po
+++ b/src/delivery/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-12-13 15:09+0000\n"
+"POT-Creation-Date: 2016-12-13 21:24+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -107,11 +107,13 @@ msgstr ""
 
 #: delivery/templates/kitchen_count.html:39
 #: delivery/templates/route_sheet.html:30
+#: delivery/templates/routes_print.html:32
 msgid "Regular"
 msgstr ""
 
 #: delivery/templates/kitchen_count.html:40
 #: delivery/templates/route_sheet.html:31
+#: delivery/templates/routes_print.html:33
 msgid "Large"
 msgstr ""
 
@@ -135,6 +137,7 @@ msgstr ""
 #: delivery/templates/kitchen_count.html:62
 #: delivery/templates/kitchen_count.html:63
 #: delivery/templates/route_sheet.html:51
+#: delivery/templates/routes_print.html:54
 msgid "Qty"
 msgstr ""
 
@@ -149,6 +152,7 @@ msgstr ""
 #: delivery/templates/kitchen_count.html:64
 #: delivery/templates/partials/generated_orders.html:10
 #: delivery/templates/route_sheet.html:48
+#: delivery/templates/routes_print.html:51
 msgid "Client"
 msgstr ""
 
@@ -339,18 +343,22 @@ msgid "Route Sheet"
 msgstr ""
 
 #: delivery/templates/route_sheet.html:29
+#: delivery/templates/routes_print.html:31
 msgid "Dish"
 msgstr ""
 
 #: delivery/templates/route_sheet.html:49
+#: delivery/templates/routes_print.html:52
 msgid "Note"
 msgstr ""
 
 #: delivery/templates/route_sheet.html:50
+#: delivery/templates/routes_print.html:53
 msgid "Item"
 msgstr ""
 
 #: delivery/templates/route_sheet.html:61
+#: delivery/templates/routes_print.html:64
 msgid "Apt"
 msgstr ""
 
@@ -362,7 +370,8 @@ msgstr ""
 msgid "Organize"
 msgstr ""
 
-#: delivery/templates/routes.html:6
+#: delivery/templates/routes.html:6 delivery/templates/routes_print.html:7
+#: delivery/templates/routes_print.html:21
 msgid "Routes Information"
 msgstr ""
 
@@ -384,6 +393,10 @@ msgstr ""
 
 #: delivery/templates/routes.html:52
 msgid "Number of orders on this route"
+msgstr ""
+
+#: delivery/templates/routes_print.html:22
+msgid "Print"
 msgstr ""
 
 #: delivery/urls.py:10

--- a/src/delivery/locale/fr/LC_MESSAGES/django.po
+++ b/src/delivery/locale/fr/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-12-13 15:09+0000\n"
+"POT-Creation-Date: 2016-12-13 21:24+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: PascalPriori <pascal.priori@savoirfairelinux.com>, 2016\n"
 "Language-Team: French (https://www.transifex.com/savoirfairelinux/"
@@ -115,11 +115,13 @@ msgstr "TOTAL"
 
 #: delivery/templates/kitchen_count.html:39
 #: delivery/templates/route_sheet.html:30
+#: delivery/templates/routes_print.html:32
 msgid "Regular"
 msgstr "Régulier"
 
 #: delivery/templates/kitchen_count.html:40
 #: delivery/templates/route_sheet.html:31
+#: delivery/templates/routes_print.html:33
 msgid "Large"
 msgstr "Grand"
 
@@ -143,6 +145,7 @@ msgstr "Ingrédients"
 #: delivery/templates/kitchen_count.html:62
 #: delivery/templates/kitchen_count.html:63
 #: delivery/templates/route_sheet.html:51
+#: delivery/templates/routes_print.html:54
 msgid "Qty"
 msgstr "Qte"
 
@@ -157,6 +160,7 @@ msgstr "Lrg"
 #: delivery/templates/kitchen_count.html:64
 #: delivery/templates/partials/generated_orders.html:10
 #: delivery/templates/route_sheet.html:48
+#: delivery/templates/routes_print.html:51
 msgid "Client"
 msgstr "Client"
 
@@ -365,18 +369,22 @@ msgid "Route Sheet"
 msgstr "Feuille d'itinéraires"
 
 #: delivery/templates/route_sheet.html:29
+#: delivery/templates/routes_print.html:31
 msgid "Dish"
 msgstr "Plat"
 
 #: delivery/templates/route_sheet.html:49
+#: delivery/templates/routes_print.html:52
 msgid "Note"
 msgstr "Note"
 
 #: delivery/templates/route_sheet.html:50
+#: delivery/templates/routes_print.html:53
 msgid "Item"
 msgstr "Article"
 
 #: delivery/templates/route_sheet.html:61
+#: delivery/templates/routes_print.html:64
 msgid "Apt"
 msgstr "App"
 
@@ -392,7 +400,8 @@ msgstr "Organiser les itinéraires"
 msgid "Organize"
 msgstr "Organiser les itinéraires"
 
-#: delivery/templates/routes.html:6
+#: delivery/templates/routes.html:6 delivery/templates/routes_print.html:7
+#: delivery/templates/routes_print.html:21
 msgid "Routes Information"
 msgstr "Information de l'itinéraire"
 
@@ -421,6 +430,10 @@ msgstr ""
 #: delivery/templates/routes.html:52
 msgid "Number of orders on this route"
 msgstr ""
+
+#: delivery/templates/routes_print.html:22
+msgid "Print"
+msgstr "Imprimer"
 
 #: delivery/urls.py:10
 msgid "^order/$"
@@ -497,9 +510,6 @@ msgstr "^saveRoute/$"
 
 #~ msgid "Print route sheet for deliveries."
 #~ msgstr "Imprimer la feuille d'itinéraires"
-
-#~ msgid "Print"
-#~ msgstr "Imprimer"
 
 #~ msgid "Save"
 #~ msgstr "Sauvegarder"

--- a/src/delivery/locale/fr/LC_MESSAGES/django.po
+++ b/src/delivery/locale/fr/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-11-22 23:01+0000\n"
+"POT-Creation-Date: 2016-12-13 15:09+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: PascalPriori <pascal.priori@savoirfairelinux.com>, 2016\n"
 "Language-Team: French (https://www.transifex.com/savoirfairelinux/"
@@ -19,13 +19,29 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
+#: delivery/filters.py:14
+msgid "Search by client name"
+msgstr ""
+
 #: delivery/forms.py:11
 msgid "Today's main dish:"
 msgstr "Plat du jour:"
 
 #: delivery/forms.py:18
-msgid "Select Ingredients:"
+#, fuzzy
+#| msgid "Select Ingredients:"
+msgid "Select main dish ingredients:"
 msgstr "Sélectionner les ingrédients:"
+
+#: delivery/forms.py:26
+#, fuzzy
+#| msgid "Select Ingredients:"
+msgid "Select sides ingredients:"
+msgstr "Sélectionner les ingrédients:"
+
+#: delivery/forms.py:37
+msgid "Please choose some Sides ingredients"
+msgstr ""
 
 #: delivery/models.py:10
 msgid "deliveries"
@@ -43,16 +59,16 @@ msgstr "Sélectionner les ingrédients"
 msgid "Main dish"
 msgstr "Plat principal"
 
-#: delivery/templates/ingredients.html:70
+#: delivery/templates/ingredients.html:63
 msgid "Restore recipe"
 msgstr "Restaurer la recette"
 
-#: delivery/templates/ingredients.html:76
-#: delivery/templates/kitchen_count.html:82 delivery/templates/routes.html:53
+#: delivery/templates/ingredients.html:77
+#: delivery/templates/kitchen_count.html:89 delivery/templates/routes.html:62
 msgid "Back"
 msgstr "Précédent"
 
-#: delivery/templates/ingredients.html:77
+#: delivery/templates/ingredients.html:79
 msgid "Next: Print Kitchen Count"
 msgstr "Suivant: Imprimer l'inventaire"
 
@@ -65,82 +81,94 @@ msgid "Kitchen Count Report"
 msgstr "Inventaire des repas"
 
 #: delivery/templates/kitchen_count.html:20
-msgid "Print the Report"
-msgstr "Imprimer l'inventaire des repas"
+#, fuzzy
+#| msgid "Print the kitchen count."
+msgid "Print the kitchen count report"
+msgstr "Imprimer l'inventaire des repas."
 
-#: delivery/templates/kitchen_count.html:22
-msgid "Download Labels"
-msgstr ""
+#: delivery/templates/kitchen_count.html:21
+#: delivery/templates/kitchen_count_steps.html:18
+msgid "Kitchen Count"
+msgstr "Inventaire des repas"
 
 #: delivery/templates/kitchen_count.html:24
-msgid "No Labels Found"
+msgid "Download the labels"
 msgstr ""
 
-#: delivery/templates/kitchen_count.html:32
+#: delivery/templates/kitchen_count.html:25
+#: delivery/templates/kitchen_count.html:29
+msgid "Labels"
+msgstr ""
+
+#: delivery/templates/kitchen_count.html:28
+msgid "No labels available"
+msgstr ""
+
+#: delivery/templates/kitchen_count.html:38
 msgid "Component"
 msgstr "Composant"
 
-#: delivery/templates/kitchen_count.html:33
-#: delivery/templates/kitchen_count.html:34
+#: delivery/templates/kitchen_count.html:39
+#: delivery/templates/kitchen_count.html:40
 msgid "TOTAL"
 msgstr "TOTAL"
 
-#: delivery/templates/kitchen_count.html:33
-#: delivery/templates/route_sheet.html:22
+#: delivery/templates/kitchen_count.html:39
+#: delivery/templates/route_sheet.html:30
 msgid "Regular"
 msgstr "Régulier"
 
-#: delivery/templates/kitchen_count.html:34
-#: delivery/templates/route_sheet.html:23
+#: delivery/templates/kitchen_count.html:40
+#: delivery/templates/route_sheet.html:31
 msgid "Large"
 msgstr "Grand"
 
-#: delivery/templates/kitchen_count.html:35
+#: delivery/templates/kitchen_count.html:41
 msgid "Dish today"
 msgstr "Plat du jour"
 
-#: delivery/templates/kitchen_count.html:36
+#: delivery/templates/kitchen_count.html:42
 msgid "Ingredients today"
 msgstr "Ingrédients du jour"
 
-#: delivery/templates/kitchen_count.html:55
+#: delivery/templates/kitchen_count.html:61
 msgid "Clashing"
 msgstr "En conflit"
 
-#: delivery/templates/kitchen_count.html:55
+#: delivery/templates/kitchen_count.html:61
 #: delivery/templates/kitchen_count_steps.html:12
 msgid "Ingredients"
 msgstr "Ingrédients"
 
-#: delivery/templates/kitchen_count.html:56
-#: delivery/templates/kitchen_count.html:57
-#: delivery/templates/route_sheet.html:43
+#: delivery/templates/kitchen_count.html:62
+#: delivery/templates/kitchen_count.html:63
+#: delivery/templates/route_sheet.html:51
 msgid "Qty"
 msgstr "Qte"
 
-#: delivery/templates/kitchen_count.html:56
+#: delivery/templates/kitchen_count.html:62
 msgid "Reg"
 msgstr "Rég"
 
-#: delivery/templates/kitchen_count.html:57
+#: delivery/templates/kitchen_count.html:63
 msgid "Lge"
 msgstr "Lrg"
 
-#: delivery/templates/kitchen_count.html:58
-#: delivery/templates/review_orders.html:77
-#: delivery/templates/route_sheet.html:40
+#: delivery/templates/kitchen_count.html:64
+#: delivery/templates/partials/generated_orders.html:10
+#: delivery/templates/route_sheet.html:48
 msgid "Client"
 msgstr "Client"
 
-#: delivery/templates/kitchen_count.html:59
+#: delivery/templates/kitchen_count.html:65
 msgid "Preparation"
 msgstr "Préparation"
 
-#: delivery/templates/kitchen_count.html:60
+#: delivery/templates/kitchen_count.html:66
 msgid "Restrictions"
 msgstr "Restrictions"
 
-#: delivery/templates/kitchen_count.html:83
+#: delivery/templates/kitchen_count.html:92
 msgid "Next: Organize Routes"
 msgstr "Suivant: Organiser les itinéraires"
 
@@ -156,10 +184,6 @@ msgstr "Réviser les commandes du jour."
 #: delivery/templates/kitchen_count_steps.html:13
 msgid "Pick ingredients for the day."
 msgstr "Sélectionner les ingrédients à utiliser aujourd'hui."
-
-#: delivery/templates/kitchen_count_steps.html:18
-msgid "Kitchen Count"
-msgstr "Inventaire des repas"
 
 #: delivery/templates/kitchen_count_steps.html:19
 msgid "Print the kitchen count."
@@ -185,30 +209,95 @@ msgstr "Organiser les itinéraires de livraison."
 msgid "Delivery route"
 msgstr "Date de livraison"
 
-#: delivery/templates/organize_route.html:36 delivery/templates/routes.html:35
+#: delivery/templates/organize_route.html:26
+msgid "Print the map and directions"
+msgstr ""
+
+#: delivery/templates/organize_route.html:27
+msgid "Map and Directions"
+msgstr ""
+
+#: delivery/templates/organize_route.html:42 delivery/templates/routes.html:43
 #, fuzzy
 #| msgid "Print the Report"
 msgid "Print the route sheet"
 msgstr "Imprimer l'inventaire des repas"
 
-#: delivery/templates/organize_route.html:37 delivery/templates/routes.html:36
+#: delivery/templates/organize_route.html:43 delivery/templates/routes.html:44
 msgid "Route sheet"
 msgstr "Feuille d'itinéraires"
 
-#: delivery/templates/organize_route.html:39
-#: delivery/templates/route_sheet.html:77
+#: delivery/templates/organize_route.html:45
+#: delivery/templates/route_sheet.html:85
 msgid "View routes list"
 msgstr ""
 
-#: delivery/templates/organize_route.html:40
-#: delivery/templates/route_sheet.html:78
+#: delivery/templates/organize_route.html:46
+#: delivery/templates/route_sheet.html:86
 #, fuzzy
 #| msgid "View Order"
 msgid "View routes"
 msgstr "Voir la commande"
 
+#: delivery/templates/partials/generated_orders.html:7
+msgid "Order"
+msgstr "Commande"
+
+#: delivery/templates/partials/generated_orders.html:8
+msgid "A unique identifier for the order."
+msgstr ""
+
+#: delivery/templates/partials/generated_orders.html:11
+msgid "Quickly access the client file."
+msgstr ""
+
+#: delivery/templates/partials/generated_orders.html:13
+msgid "Delivery Date"
+msgstr "Date de livraison"
+
+#: delivery/templates/partials/generated_orders.html:14
+msgid "The delivery date planned for the order."
+msgstr ""
+
+#: delivery/templates/partials/generated_orders.html:16
+msgid "Route"
+msgstr "Itinéraire"
+
+#: delivery/templates/partials/generated_orders.html:17
+#, fuzzy
+#| msgid "Delivery Date"
+msgid "The delivery route."
+msgstr "Date de livraison"
+
+#: delivery/templates/partials/generated_orders.html:19
+msgid "Status"
+msgstr "État"
+
+#: delivery/templates/partials/generated_orders.html:20
+msgid "Display only Ordered orders."
+msgstr ""
+
+#: delivery/templates/partials/generated_orders.html:22
+msgid "Amount"
+msgstr "Montant"
+
+#: delivery/templates/partials/generated_orders.html:23
+msgid "Total amount in $CAD."
+msgstr ""
+
+#: delivery/templates/partials/generated_orders.html:37
+msgid "Fix geolocalization."
+msgstr ""
+
+#: delivery/templates/partials/generated_orders.html:43
+msgid "Review or change the status of the order."
+msgstr ""
+
+#: delivery/templates/partials/generated_orders.html:44
+msgid "Change the details of the order."
+msgstr ""
+
 #: delivery/templates/review_orders.html:6
-#: delivery/templates/review_orders.html:65
 msgid "Orders"
 msgstr "Commandes"
 
@@ -216,52 +305,46 @@ msgstr "Commandes"
 msgid "Orders of the day"
 msgstr "Commandes du jour"
 
-#: delivery/templates/review_orders.html:74
-msgid "Order"
-msgstr "Commande"
-
-#: delivery/templates/review_orders.html:75
-#: delivery/templates/review_orders.html:81
-#: delivery/templates/review_orders.html:84
-#: delivery/templates/review_orders.html:90
-#, fuzzy
-#| msgid "Order"
-msgid "Order\\"
-msgstr "Commande"
-
-#: delivery/templates/review_orders.html:78
-msgid "Quickly access the client\\"
+#: delivery/templates/review_orders.html:29
+msgid ""
+"Orders of the day include ongoing and episodic clients. Only Ordered orders "
+"from Active clients are included."
 msgstr ""
 
-#: delivery/templates/review_orders.html:80
-msgid "Delivery Date"
-msgstr "Date de livraison"
+#: delivery/templates/review_orders.html:55
+msgid "Generate orders"
+msgstr ""
 
-#: delivery/templates/review_orders.html:83
-msgid "Route"
-msgstr "Itinéraire"
+#: delivery/templates/review_orders.html:58
+#, python-format
+msgid ""
+"\n"
+"                        <span>%(count)s</span>\n"
+"                        &nbsp;today\n"
+"                    "
+msgstr ""
+
+#: delivery/templates/review_orders.html:69
+#, fuzzy
+#| msgid "Review Orders"
+msgid "Review"
+msgstr "Réviser les commandes"
+
+#: delivery/templates/review_orders.html:76
+#, fuzzy
+#| msgid "Client"
+msgid "Client name"
+msgstr "Client"
 
 #: delivery/templates/review_orders.html:86
-msgid "Status"
-msgstr "État"
-
-#: delivery/templates/review_orders.html:87
-msgid "Display only Ordered orders."
+msgid "Reset"
 msgstr ""
 
-#: delivery/templates/review_orders.html:89
-msgid "Amount"
-msgstr "Montant"
+#: delivery/templates/review_orders.html:87
+msgid "Search"
+msgstr ""
 
-#: delivery/templates/review_orders.html:103
-msgid "View Order"
-msgstr "Voir la commande"
-
-#: delivery/templates/review_orders.html:111
-msgid "orders today"
-msgstr "Commandes du jour"
-
-#: delivery/templates/review_orders.html:117
+#: delivery/templates/review_orders.html:95
 msgid "OK, I'm ready"
 msgstr "Allons-y!"
 
@@ -269,29 +352,41 @@ msgstr "Allons-y!"
 msgid "Delivery Route Sheet"
 msgstr "Feuille d'itinéraire"
 
-#: delivery/templates/route_sheet.html:21
+#: delivery/templates/route_sheet.html:19
+#, fuzzy
+#| msgid "Print the Report"
+msgid "Print the route sheet."
+msgstr "Imprimer l'inventaire des repas"
+
+#: delivery/templates/route_sheet.html:20
+#, fuzzy
+#| msgid "Route sheet"
+msgid "Route Sheet"
+msgstr "Feuille d'itinéraires"
+
+#: delivery/templates/route_sheet.html:29
 msgid "Dish"
 msgstr "Plat"
 
-#: delivery/templates/route_sheet.html:41
+#: delivery/templates/route_sheet.html:49
 msgid "Note"
 msgstr "Note"
 
-#: delivery/templates/route_sheet.html:42
+#: delivery/templates/route_sheet.html:50
 msgid "Item"
 msgstr "Article"
 
-#: delivery/templates/route_sheet.html:53
+#: delivery/templates/route_sheet.html:61
 msgid "Apt"
 msgstr "App"
 
-#: delivery/templates/route_sheet.html:74 delivery/templates/routes.html:32
+#: delivery/templates/route_sheet.html:82 delivery/templates/routes.html:40
 #, fuzzy
 #| msgid "Organize Routes"
 msgid "Organize the route"
 msgstr "Organiser les itinéraires"
 
-#: delivery/templates/route_sheet.html:75 delivery/templates/routes.html:33
+#: delivery/templates/route_sheet.html:83 delivery/templates/routes.html:41
 #, fuzzy
 #| msgid "Organize Routes"
 msgid "Organize"
@@ -307,11 +402,23 @@ msgstr "Information de l'itinéraire"
 msgid "Delivery routes"
 msgstr "Date de livraison"
 
-#: delivery/templates/routes.html:43
+#: delivery/templates/routes.html:28
+#, fuzzy
+#| msgid "Print the Report"
+msgid "Print the route sheets"
+msgstr "Imprimer l'inventaire des repas"
+
+#: delivery/templates/routes.html:29
+#, fuzzy
+#| msgid "Route sheet"
+msgid "Route Sheets"
+msgstr "Feuille d'itinéraires"
+
+#: delivery/templates/routes.html:51
 msgid "Cycling map"
 msgstr ""
 
-#: delivery/templates/routes.html:44
+#: delivery/templates/routes.html:52
 msgid "Number of orders on this route"
 msgstr ""
 
@@ -373,6 +480,20 @@ msgstr "^refresh_orders/$"
 #| msgid "^saveRoute/$"
 msgid "^save_route/$"
 msgstr "^saveRoute/$"
+
+#~ msgid "Print the Report"
+#~ msgstr "Imprimer l'inventaire des repas"
+
+#, fuzzy
+#~| msgid "Order"
+#~ msgid "Order\\"
+#~ msgstr "Commande"
+
+#~ msgid "View Order"
+#~ msgstr "Voir la commande"
+
+#~ msgid "orders today"
+#~ msgstr "Commandes du jour"
 
 #~ msgid "Print route sheet for deliveries."
 #~ msgstr "Imprimer la feuille d'itinéraires"

--- a/src/delivery/templates/routes.html
+++ b/src/delivery/templates/routes.html
@@ -25,7 +25,7 @@
 
 <div class="row">
     <div class="column">
-        <a href="javascript:window.print()" class="ui tiny labeled icon right basic pink button" title="{% trans 'Print the route sheets' %}">
+        <a href="?print=yes" class="ui big labeled icon right basic pink button" title="{% trans 'Print the route sheets' %}" target="_blank">
             <i class="print icon"></i>{% trans 'Route Sheets' %}
         </a>
     </div>

--- a/src/delivery/templates/routes.html
+++ b/src/delivery/templates/routes.html
@@ -24,6 +24,14 @@
 </div>
 
 <div class="row">
+    <div class="column">
+        <a href="javascript:window.print()" class="ui tiny labeled icon right basic pink button" title="{% trans 'Print the route sheets' %}">
+            <i class="print icon"></i>{% trans 'Route Sheets' %}
+        </a>
+    </div>
+</div>
+
+<div class="row">
     <div class="sixteen wide column">
       <div class="ui middle aligned divided list">
           {% for route, orders in routes %}

--- a/src/delivery/templates/routes_print.html
+++ b/src/delivery/templates/routes_print.html
@@ -1,0 +1,87 @@
+{% load i18n %}
+{% load static %}
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>{% trans 'Routes Information' %}</title>
+    <style>
+      table {width: 100%;border-collapse:collapse}
+      table th {text-align:left}
+      table tr {border-bottom: 1px solid black}
+      @media only screen {
+        body {max-width:1024px}  /* for display */
+      }
+      @media only print {
+        .no-print {display:none!important;visilibity:hidden!important}
+      }
+    </style>
+  </head>
+  <body>
+    <h1>{% trans "Routes Information" %} <small>{% now "j F Y" %}</small></h1>
+    <button onclick="javascript:window.print()" class="no-print">{% trans 'Print' %}</button>
+
+    {% for route_dict in routes_dict.values %}
+    {% if route_dict.summary_lines or route_dict.detail_lines %}
+    <h2>{{ route_dict.route.name }}</h2>
+    <p>
+      <table>
+        <thead>
+         <tr>
+          <th>{% trans 'Dish' %}</th>
+          <th>{% trans 'Regular' %}</th>
+          <th>{% trans 'Large' %}</th>
+         </tr>
+        </thead>
+        <tbody>
+          {% for obj in route_dict.summary_lines %}
+            <tr>
+              <td><strong>{{obj.component_group}}</strong></td>
+              <td>{{obj.rqty}}</td>
+              <td>{{obj.lqty}}</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </p>
+    <p>
+      <table class="ui very compact celled  table">
+        <thead>
+         <tr class="top center aligned">
+          <th class="three wide">{% trans 'Client' %}</th>
+          <th class="six wide">{% trans 'Note' %}</th>
+          <th class="two wide">{% trans 'Item' %}</th>
+          <th class="one wide">{% trans 'Qty' %}</th>
+         </tr>
+         </thead>
+        <tbody>
+          {% for obj in route_dict.detail_lines %}
+            <tr>
+              <td>
+                <strong>{{obj.firstname}} {{obj.lastname}}</strong><br>
+                {{obj.street}}<br>
+                {% if obj.apartment %}
+                  {% trans 'Apt' %} {{obj.apartment}}<br>
+                {% endif %}
+                {{obj.phone}}
+              </td>
+              <td class="left aligned">{{obj.delivery_note}}</td>
+              <td>
+                {% for item in obj.delivery_items %}
+                  {{item.component_group}} {% if item.remark %}{{item.remark}}{% endif %}<br>
+                {% endfor %}
+              </td>
+              <td class="center aligned">
+                {% for item in obj.delivery_items %}
+                  {{item.total_quantity}}<br>
+                {% endfor %}
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </p>
+    {% endif %}
+    {% endfor %}
+  </body>
+</html>

--- a/src/delivery/tests.py
+++ b/src/delivery/tests.py
@@ -370,3 +370,21 @@ class KitchenCountOrderFilterTestCase(SousChefTestMixin, TestCase):
                 Q(client__member__lastname__icontains='john') |
                 Q(client__member__lastname__icontains='doe')
             )))
+
+
+class RoutesInformationViewTestCase(SousChefTestMixin, TestCase):
+    fixtures = ['sample_data']
+
+    def setUp(self):
+        super(RoutesInformationViewTestCase, self).setUp()
+        self.force_login()
+
+    def test_can_embed_additional_route_sheet_information_when_printing(self):
+        # Setup
+        url = reverse('delivery:routes')
+        # Run
+        response_1 = self.client.get(url)
+        response_2 = self.client.get(url, {'print': 'yes'})
+        # Check
+        self.assertNotIn('routes_dict', response_1.context)
+        self.assertIn('routes_dict', response_2.context)

--- a/src/delivery/views.py
+++ b/src/delivery/views.py
@@ -207,11 +207,14 @@ class RouteInformation(LoginRequiredMixin, generic.ListView):
 class RoutesInformation(LoginRequiredMixin, generic.ListView):
     # Display all the route information for a given day
     model = Delivery
-    template_name = "routes.html"
+
+    @property
+    def doprint(self):
+        return self.request.GET.get('print', False)
 
     def get_context_data(self, **kwargs):
-
         context = super(RoutesInformation, self).get_context_data(**kwargs)
+
         routes = Route.objects.all()
         orders = []
         for route in routes:
@@ -221,7 +224,25 @@ class RoutesInformation(LoginRequiredMixin, generic.ListView):
                      route.id).count()))
         context['routes'] = orders
 
+        # Embeds additional information if we are displaying the print version
+        # of the routes information page.
+        if self.doprint:
+            date = datetime.date.today()
+            routes_dict = {}
+            for route in routes:
+                date_stored, route_client_ids = route.get_client_sequence()
+                route_list = Order.get_delivery_list(date, route.id)
+                route_list = sort_sequence_ids(route_list, route_client_ids)
+                summary_lines, detail_lines = drs_make_lines(route_list, date)
+                routes_dict[route.id] = {
+                    'route': route, 'summary_lines': summary_lines,
+                    'detail_lines': detail_lines}
+            context['routes_dict'] = routes_dict
+
         return context
+
+    def get_template_names(self):
+        return ['routes_print.html', ] if self.doprint else ['routes.html', ]
 
 
 class OrganizeRoute(LoginRequiredMixin, generic.ListView):


### PR DESCRIPTION
## Fixes #571 by ellmetha

### Changes proposed in this pull request:

* Add a button in the "Routes Information" page allowing to print all the route sheets

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

* Go to the "Routes Information" page and use the print button

### New translatable strings

- [X] I have updated .po files with new strings


