### PR TITLE
Fix 572

### DIFF
--- a/src/order/forms.py
+++ b/src/order/forms.py
@@ -8,7 +8,7 @@ from extra_views import InlineFormSet
 
 from member.models import Client
 
-from meal.models import COMPONENT_GROUP_CHOICES
+from meal.models import COMPONENT_GROUP_CHOICES, COMPONENT_GROUP_CHOICES_SIDES
 from order.models import Order_item, SIZE_CHOICES, OrderStatusChange, \
     ORDER_ITEM_TYPE_CHOICES
 
@@ -71,6 +71,8 @@ class CreateOrdersBatchForm(forms.Form):
                 )
 
                 for meal, placeholder in COMPONENT_GROUP_CHOICES:
+                    if meal is COMPONENT_GROUP_CHOICES_SIDES:
+                        continue  # don't put "sides" on the form
                     self.fields[
                         '{}_{}_quantity'.format(meal, d)
                     ] = forms.IntegerField(

--- a/src/order/tests.py
+++ b/src/order/tests.py
@@ -537,7 +537,6 @@ class OrderCreateBatchTestCase(SousChefTestMixin, TestCase):
             'green_salad_2016-12-12_quantity': 1,
             'pudding_2016-12-12_quantity': 0,
             'compote_2016-12-12_quantity': 0,
-            'sides_2016-12-12_quantity': 0,
             'main_dish_2016-12-14_quantity': 1,
             'size_2016-12-14': 'L',
             'dessert_2016-12-14_quantity': 1,
@@ -545,8 +544,7 @@ class OrderCreateBatchTestCase(SousChefTestMixin, TestCase):
             'fruit_salad_2016-12-14_quantity': 0,
             'green_salad_2016-12-14_quantity': 1,
             'pudding_2016-12-14_quantity': 0,
-            'compote_2016-12-14_quantity': 0,
-            'sides_2016-12-14_quantity': 0
+            'compote_2016-12-14_quantity': 0
         })
         self.assertEqual(response.status_code, 302)  # form submit redirect
         created_orders = Order.objects.filter(
@@ -574,7 +572,6 @@ class OrderCreateBatchTestCase(SousChefTestMixin, TestCase):
             'green_salad_2016-12-12_quantity': 1,
             'pudding_2016-12-12_quantity': 0,
             'compote_2016-12-12_quantity': 0,
-            'sides_2016-12-12_quantity': 0,
             'main_dish_2016-12-14_quantity': 1,
             'size_2016-12-14': 'L',
             'dessert_2016-12-14_quantity': 1,
@@ -582,8 +579,7 @@ class OrderCreateBatchTestCase(SousChefTestMixin, TestCase):
             'fruit_salad_2016-12-14_quantity': 0,
             'green_salad_2016-12-14_quantity': 1,
             'pudding_2016-12-14_quantity': 0,
-            'compote_2016-12-14_quantity': 0,
-            'sides_2016-12-14_quantity': 0
+            'compote_2016-12-14_quantity': 0
         })
         self.assertEqual(response.status_code, 200)  # stay on form page
         created_orders = Order.objects.filter(
@@ -606,8 +602,6 @@ class OrderCreateBatchTestCase(SousChefTestMixin, TestCase):
             'fruit_salad_2016-12-12_quantity': 0,
             'green_salad_2016-12-12_quantity': 1,
             'pudding_2016-12-12_quantity': 0,
-            'compote_2016-12-12_quantity': 0,
-            'sides_2016-12-12_quantity': 0,
             'main_dish_2016-12-14_quantity': 1,
             'size_2016-12-14': 'L',
             'dessert_2016-12-14_quantity': 1,
@@ -616,7 +610,7 @@ class OrderCreateBatchTestCase(SousChefTestMixin, TestCase):
             'green_salad_2016-12-14_quantity': 1,
             'pudding_2016-12-14_quantity': 0,
             'compote_2016-12-14_quantity': 0
-            # lacks: sides_2016-12-12_quantity
+            # lacks: compote_2016-12-12_quantity
         })
         self.assertEqual(response.status_code, 200)  # stay on form page
         created_orders = Order.objects.filter(
@@ -639,8 +633,7 @@ class OrderCreateBatchTestCase(SousChefTestMixin, TestCase):
             'fruit_salad_2016-12-12_quantity': 0,
             'green_salad_2016-12-12_quantity': 1,
             'pudding_2016-12-12_quantity': 0,
-            'compote_2016-12-12_quantity': 0,
-            'sides_2016-12-12_quantity': 0
+            'compote_2016-12-12_quantity': 0
         })
         self.assertEqual(response.status_code, 200)  # stay on form page
         created_orders = Order.objects.filter(
@@ -661,8 +654,7 @@ class OrderCreateBatchTestCase(SousChefTestMixin, TestCase):
             'fruit_salad_2016-12-12_quantity': 0,
             'green_salad_2016-12-12_quantity': 1,
             'pudding_2016-12-12_quantity': 0,
-            'compote_2016-12-12_quantity': 0,
-            'sides_2016-12-12_quantity': 0
+            'compote_2016-12-12_quantity': 0
         })
         self.assertEqual(response.status_code, 200)  # stay on form page
         created_orders = Order.objects.filter(

--- a/src/order/views.py
+++ b/src/order/views.py
@@ -18,7 +18,7 @@ from order.mixins import AjaxableResponseMixin, FormValidAjaxableResponseMixin
 from order.forms import CreateOrderItem, UpdateOrderItem, \
     CreateOrdersBatchForm, OrderStatusChangeForm
 
-from meal.models import COMPONENT_GROUP_CHOICES
+from meal.models import COMPONENT_GROUP_CHOICES, COMPONENT_GROUP_CHOICES_SIDES
 from meal.settings import COMPONENT_SYSTEM_DEFAULT
 from member.models import Client, DAYS_OF_WEEK
 
@@ -127,7 +127,10 @@ class CreateOrdersBatch(generic.FormView):
     def get_context_data(self, **kwargs):
         context = super(CreateOrdersBatch, self).get_context_data(**kwargs)
         # Define here any needed variable for template
-        context["meals"] = COMPONENT_GROUP_CHOICES
+        context["meals"] = filter(
+            lambda tup: tup[0] != COMPONENT_GROUP_CHOICES_SIDES,
+            COMPONENT_GROUP_CHOICES
+        )
 
         # delivery_dates
         if self.request.method == "POST" and \


### PR DESCRIPTION
## Fixes #572  by lingxiaoyang

### Changes proposed in this pull request:

* Remove "Sides" field in order batch create page: http://localhost:8000/order/create/batch (and also in unit test data)
* In `Order.objects.create_order()`, deduct free side dishes according to the number of main dishes. (1 main dish comes with 1 free side dish). The free side dishes are set `billable_flag=False`.
* Unit test.
* Add `transaction.atomic` on `create_order()`: if any error occurs inside this function, the db will revert automatically.

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

1. Go to order batch create page. Create a new order with main dish and side dish.
2. Check created order. There should be non-billable side dishes.

### Deployment notes and migration

none

### New translatable strings

none

### Additional notes

none
