### PR TITLE
Fixed #577. Fixed #578

### DIFF
--- a/src/member/forms.py
+++ b/src/member/forms.py
@@ -8,7 +8,7 @@ from localflavor.ca.forms import (
     CAPhoneNumberField, CAPostalCodeField
 )
 from meal.models import Ingredient, Component, COMPONENT_GROUP_CHOICES, \
-    Restricted_item
+    Restricted_item, COMPONENT_GROUP_CHOICES_SIDES
 from order.models import SIZE_CHOICES
 from member.models import (
     Member, Client, RATE_TYPE, CONTACT_TYPE_CHOICES, Option,
@@ -176,6 +176,8 @@ class ClientRestrictionsInformation(forms.Form):
             )
 
             for meal, placeholder in COMPONENT_GROUP_CHOICES:
+                if meal is COMPONENT_GROUP_CHOICES_SIDES:
+                    continue  # skip "Sides"
                 self.fields['{}_{}_quantity'.format(meal, day)] = \
                     forms.IntegerField(
                         widget=forms.TextInput(

--- a/src/member/tests.py
+++ b/src/member/tests.py
@@ -349,6 +349,99 @@ class ClientOptionTestCase(TestCase):
         )
 
 
+class ClientMealDefaultWeekTestCase(TestCase):
+    fixtures = ['routes']
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.clientTest = ClientFactory(
+            delivery_type="O",
+            meal_default_week={
+                "main_dish_monday_quantity": 1,
+                "size_monday": "R",
+                "diabetic_monday_quantity": 2,
+                "fruit_salad_monday_quantity": 1,
+
+                "main_dish_tuesday_quantity": 0,
+                "size_tuesday": "L",
+                "compote_tuesday_quantity": 1,
+
+                # wednesday invalid
+                "main_dish_wednesday_quantity": 0,
+                "dessert_wednesday_quantity": 0,
+                "size_wednesday": "R",
+
+                # thursday invalid (no size)
+                "main_dish_thursday_quantity": 1,
+                "diabetic_thursday_quantity": 2,
+                "fruit_salad_thursday_quantity": 1,
+
+                # friday, saturday, sunday nothing
+            }
+        )
+        meals_schedule_option = Option.objects.create(
+            name='meals_schedule', option_group='dish'
+        )
+        Client_option.objects.create(
+            client=cls.clientTest,
+            option=meals_schedule_option,
+            value=json.dumps(['monday', 'wednesday', 'friday']),
+        )
+
+    def test_client_meals_default(self):
+        """
+        Tests: Client.meals_default
+        """
+        md = dict(self.clientTest.meals_default)
+        self.assertEqual(md['monday'], {
+            'main_dish': 1,
+            'size': 'R',
+            'dessert': 0,
+            'diabetic': 2,
+            'fruit_salad': 1,
+            'green_salad': 0,
+            'pudding': 0,
+            'compote': 0
+        })
+        self.assertEqual(md['tuesday'], {
+            'main_dish': 0,
+            'size': 'L',
+            'dessert': 0,
+            'diabetic': 0,
+            'fruit_salad': 0,
+            'green_salad': 0,
+            'pudding': 0,
+            'compote': 1
+        })
+        self.assertEqual(md['wednesday'], None)
+        self.assertEqual(md['thursday'], None)
+        self.assertEqual(md['friday'], None)
+        self.assertEqual(md['saturday'], None)
+        self.assertEqual(md['sunday'], None)
+
+    def test_client_meals_schedule(self):
+        """
+        Tests: Client.meals_schedule
+        """
+        ms = dict(self.clientTest.meals_schedule)
+        self.assertEqual(ms['monday'], {
+            'main_dish': 1,
+            'size': 'R',
+            'dessert': 0,
+            'diabetic': 2,
+            'fruit_salad': 1,
+            'green_salad': 0,
+            'pudding': 0,
+            'compote': 0
+        })
+        self.assertEqual(ms['tuesday'], None)  # no delivery scheduled
+        self.assertEqual(ms['wednesday'], None)
+        self.assertEqual(ms['thursday'], None)
+        self.assertEqual(ms['friday'], None)
+        self.assertEqual(ms['saturday'], None)
+        self.assertEqual(ms['sunday'], None)
+
+
 class ClientEpisodicMealsPrefsTestCase(TestCase):
 
     fixtures = ['routes']


### PR DESCRIPTION
## Fixes #577  and #578  by lingxiaoyang

### Changes proposed in this pull request:

* Treat "sides" as a special value in meal components and remove it from client preference form.
* `Client.meals_default` now allows None fields in JSON field `Client.meal_default_week`. It sets the value as 0 in the output.
* Unit test on behaviors of `Client.meals_default` and `Client.meals_schedule`.

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

1. Go to Client preference form, the "Sides" should not exist anymore.
2. Manually modify `Client.meal_default_week` in Django admin. Remove some zero fields. Then go to Client preference view, and it should not show the system default but the remaining values in this JSON field.

### Deployment notes and migration

none

### New translatable strings

none

### Additional notes

none

