### PR TITLE
Correct the display of the list of note

### DIFF
--- a/src/note/templates/notes_list.html
+++ b/src/note/templates/notes_list.html
@@ -58,11 +58,9 @@
         </div>
       </form>
     </div>
-</div>
-
-<div class="ui relaxed divided list">
-    {% for note in notes %}
-    <div class="item">
+    <div class="ui relaxed divided list">
+      {% for note in notes %}
+      <div class="item">
         <div class="right floated content">
             {% if note.is_read %}
             <a class="ui tiny  button " href="{% url 'note:unread' note.id %}">
@@ -85,31 +83,30 @@
                 </div>
             </div>
         </div>
+      </div>
+      {% endfor %}
     </div>
-    {% endfor %}
-</div>
 
-{% if is_paginated %}
+    {% if is_paginated %}
 
-<div class="ui row">
-<div class="ui pagination menu" style="margin: 2em auto; width=100%;";>
-    {% if page_obj.has_previous %}
-    <a class="icon item"
-       href="{{ request.path }}{{ get }}page={{ page_obj.previous_page_number }}">
-        <i class="left arrow icon"></i>
-    </a>
+    <div class="ui row">
+      <div class="ui pagination menu" style="margin: 2em auto; width=100%;";>
+        {% if page_obj.has_previous %}
+        <a class="icon item"
+           href="{{ request.path }}{{ get }}page={{ page_obj.previous_page_number }}">
+            <i class="left arrow icon"></i>
+        </a>
+        {% endif %}
+        <a class="active item">
+          {{ page_obj.number }} {% trans "of" %} {{ page_obj.paginator.num_pages }}
+        </a>
+        {% if page_obj.has_next %}
+        <a class="icon item"
+           href="{{ request.path }}{{ get }}page={{ page_obj.next_page_number }}">
+            <i class="right arrow icon"></i>
+        </a>
+        {% endif %}
+      </div>
+    </div>
     {% endif %}
-    <a class="active item">
-        {{ page_obj.number }} {% trans "of" %} {{ page_obj.paginator.num_pages }}
-    </a>
-    {% if page_obj.has_next %}
-    <a class="icon item"
-       href="{{ request.path }}{{ get }}page={{ page_obj.next_page_number }}">
-        <i class="right arrow icon"></i>
-    </a>
-    {% endif %}
-</div>
-</div>
-{% endif %}
-
 {% endblock %}


### PR DESCRIPTION
## Fixes #576  

### Changes proposed in this pull request:
* Move the last div of note_list.html inside the previous div

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change
Create a note with a note field like toto
Verify the display (The note must be above the reset/research button)

