### PR TITLE
Fix 581

### DIFF
--- a/src/billing/templates/billing/list.html
+++ b/src/billing/templates/billing/list.html
@@ -67,7 +67,7 @@
           <td><i class="hashtag icon"></i>{{billing.id}}</td>
         <td><i class="calendar icon"></i><strong>{{billing.billing_period|date:"F Y"}}</strong></td>
         <td class="center aligned"><i class="dollar icon"></i>{{billing.total_amount}}</td>
-        <td class="center aligned">{{billing.orders.all.count}}</td>
+        <td class="center aligned">{{billing.orders__count}}</td>
         <td>
           <a class="ui basic icon button"  href="{% url 'billing:view' pk=billing.id %}"><i class="icon unhide"></i></a>
           <a class="ui basic icon button"  href=""><i class="icon edit"></i></a>

--- a/src/billing/templates/billing/view_orders.html
+++ b/src/billing/templates/billing/view_orders.html
@@ -59,7 +59,7 @@
     <th class="">{% trans 'Actions' %}</th>
   </thead>
   <tbody>
-    {% for order in orders.all %}
+    {% for order in orders %}
     <tr>
       <td><i class="hashtag icon"></i>{{order.id}}</td>
       <td><a href="{% url 'member:client_information' pk=order.client.id %}">{{order.client}}

--- a/src/delivery/templates/review_orders.html
+++ b/src/delivery/templates/review_orders.html
@@ -54,12 +54,14 @@
                 <div class="ui pink big button orders" data-url="{% url 'delivery:refresh_orders'%}">
                     <i class="refresh icon"></i> {% trans 'Generate orders' %}
                 </div>
-                <a class="ui basic left pointing pink label orders-count" data-order-count={{orders.count}}>
-                    {% blocktrans with count=orders.count  %}
+                {% with count=orders.count %}
+                <a class="ui basic left pointing pink label orders-count" data-order-count={{count}}>
+                    {% blocktrans %}
                         <span>{{ count }}</span>
                         &nbsp;today
                     {% endblocktrans %}
                 </a>
+                {% endwith %}
             </div>
         </div>
     </div>

--- a/src/delivery/views.py
+++ b/src/delivery/views.py
@@ -184,6 +184,7 @@ class MealInformation(LoginRequiredMixin, generic.View):
                         ingredient=ing,
                         date=date)
                     ci.save()
+
                 # Create menu and its components for today
                 compnames = [component.name]  # main dish
                 # take first sorted name of each other component group
@@ -406,7 +407,8 @@ def kcr_make_lines(kitchen_list, date):
                     lqty=0,
                     name='',
                     ingredients=''))
-            if component_group == COMPONENT_GROUP_CHOICES_MAIN_DISH:
+            if (component_group == COMPONENT_GROUP_CHOICES_MAIN_DISH and
+                    component_lines[component_group].name == ''):
                 component_lines[component_group] = \
                     component_lines[component_group]._replace(
                         name=meal_component.name,

--- a/src/delivery/views.py
+++ b/src/delivery/views.py
@@ -52,6 +52,18 @@ class Orderlist(LoginRequiredMixin, FilterView):
     def get_queryset(self):
         queryset = Order.objects.get_shippable_orders().order_by(
             'client__route__pk', 'pk'
+        ).prefetch_related('orders').select_related(
+            'client__member',
+            'client__route',
+            'client__member__address'
+        ).only(
+            'delivery_date',
+            'status',
+            'client__member__firstname',
+            'client__member__lastname',
+            'client__route__name',
+            'client__member__address__latitude',
+            'client__member__address__longitude'
         )
         return queryset
 

--- a/src/meal/models.py
+++ b/src/meal/models.py
@@ -97,6 +97,7 @@ class Component(models.Model):
         """Returns a list of the actual ingredients
         of a component for the delivery date."""
         q = Component_ingredient.objects.\
+            select_related('ingredient').\
             filter(component__id=component_id, date=delivery_date)
         return [ci.ingredient for ci in q]
 

--- a/src/meal/models.py
+++ b/src/meal/models.py
@@ -105,6 +105,7 @@ class Component(models.Model):
     def get_recipe_ingredients(component_id):
         """Returns a list of the ingredients in the recipe of a component."""
         q = Component_ingredient.objects.\
+            select_related('ingredient').\
             filter(component__id=component_id, date=None)
         return [ci.ingredient for ci in q]
 

--- a/src/member/models.py
+++ b/src/member/models.py
@@ -122,7 +122,9 @@ class Member(models.Model):
     @property
     def home_phone(self):
         try:
-            val_orig = self.member_contact.filter(type=HOME).first().value
+            val_orig = next(
+                mc.value for mc in self.member_contact.all() if mc.type == HOME
+            )
             f = CAPhoneNumberExtField()
             val_clean = f.clean(val_orig)
             if val_orig != val_clean:
@@ -131,14 +133,16 @@ class Member(models.Model):
                 return val_clean
             return val_orig
         except ValidationError as error:
-            return self.member_contact.filter(type=HOME).first().value
+            return val_orig
         except:
             return ""
 
     @property
     def cell_phone(self):
         try:
-            val_orig = self.member_contact.filter(type=CELL).first().value
+            val_orig = next(
+                mc.value for mc in self.member_contact.all() if mc.type == CELL
+            )
             f = CAPhoneNumberExtField()
             val_clean = f.clean(val_orig)
             if val_orig != val_clean:
@@ -147,14 +151,16 @@ class Member(models.Model):
                 return val_clean
             return val_orig
         except ValidationError as error:
-            return self.member_contact.filter(type=CELL).first().value
+            return val_orig
         except:
             return ""
 
     @property
     def work_phone(self):
         try:
-            val_orig = self.member_contact.filter(type=WORK).first().value
+            val_orig = next(
+                mc.value for mc in self.member_contact.all() if mc.type == WORK
+            )
             f = CAPhoneNumberExtField()
             val_clean = f.clean(val_orig)
             if val_orig != val_clean:
@@ -163,14 +169,17 @@ class Member(models.Model):
                 return val_clean
             return val_orig
         except ValidationError as error:
-            return self.member_contact.filter(type=WORK).first().value
+            return val_orig
         except:
             return ""
 
     @property
     def email(self):
         try:
-            return self.member_contact.all().filter(type=EMAIL).first().value
+            return next(
+                mc.value for mc in self.member_contact.all()
+                if mc.type == EMAIL
+            )
         except:
             return ""
 
@@ -662,8 +671,9 @@ class Client(models.Model):
         """
         defaults = self.meals_default
         prefs = []
+        simple_meals_schedule = self.simple_meals_schedule
         for day, meal_schedule in defaults:
-            if day not in self.simple_meals_schedule:
+            if day not in simple_meals_schedule:
                 prefs.append((day, None))
             else:
                 prefs.append((day, meal_schedule))

--- a/src/member/templates/client/partials/prefs.html
+++ b/src/member/templates/client/partials/prefs.html
@@ -3,12 +3,13 @@
 
 {% if client.delivery_type == 'O' %}
 <div class="ui middle aligned divided list">
+  {% with simple_meals_schedule=client.simple_meals_schedule %}
     {% for day, meal_default in client.meals_schedule %}
     <div class="item">
         <div class="content">
           <a class="header">{{day|title}}</a>
           <div class="description">
-              {% if day in client.simple_meals_schedule %}
+              {% if day in simple_meals_schedule %}
                 {{ meal_default|readable_prefs }}
               {% else %}
                 {% trans 'No delivery.' %}
@@ -16,7 +17,8 @@
           </div>
         </div>
     </div>
-  {% endfor %}
+    {% endfor %}
+  {% endwith %}
 </div>
 {% else %}
 <div class="ui middle aligned divided list">

--- a/src/note/forms.py
+++ b/src/note/forms.py
@@ -1,8 +1,18 @@
 from django import forms
+from member.models import Client
 from note.models import Note
 
 
 class NoteForm(forms.ModelForm):
+
+    def __init__(self, *args, **kwargs):
+        super(NoteForm, self).__init__(*args, **kwargs)
+        self.fields['client'].queryset = Client.objects.all().select_related(
+            'member'
+        ).only(
+            'member__firstname',
+            'member__lastname'
+        )
 
     class Meta:
         model = Note

--- a/src/note/views.py
+++ b/src/note/views.py
@@ -27,7 +27,9 @@ class NoteList(generic.ListView):
 
     def get_queryset(self):
         uf = NoteFilter(self.request.GET)
-        return uf.qs
+        return uf.qs.select_related(
+            'client__member'
+        )
 
         # The queryset must be client
 

--- a/src/order/forms.py
+++ b/src/order/forms.py
@@ -86,7 +86,12 @@ class CreateOrdersBatchForm(forms.Form):
         required=True,
         label=_('Client'),
         widget=BatchFormClientSelect(attrs={'class': 'ui search dropdown'}),
-        queryset=Client.active.all(),
+        queryset=Client.active.all().select_related(
+            'member'
+        ).only(
+            'member__firstname',
+            'member__lastname'
+        )
     )
 
     delivery_dates = forms.CharField(


### PR DESCRIPTION
## Fixes #581  by lingxiaoyang

### Changes proposed in this pull request:

* Add several `select_related` and `prefetch_related` to gather as much needed information from DB in one SQL query. Primarily in `queryset` or `get_queryset()` in view functions. There are also few in model properties.
* Add several `{% with %}` in templates to store DB values for multiple uses.
* In Python code, add several temporary variables to store DB values with multiple uses.
* Rewrite `models.Billing.summary` property, use ORMed Django objects to calculate billing summary, allowing optimization. (summary result verified with older version)

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

1. Install Django Debug Toolbar
2. Browse each APIs, watch statistics of SQL queries in the toolbar.
3. Test billing summary view. Make sure the output has no difference. (because of the rewrite of the calculation)

### Deployment notes and migration

none

### New translatable strings

none

### Additional notes

1. Django Debug Toolbar NOT included in this PR.
2. Not including as would be fixed by @lamontfr (the same cause):
 - http://localhost:8000/delivery/meal/
 - http://localhost:8000/delivery/kitchen_count/
3. Not including as not necessary (comparing the expected performance improvement and complexity):
 - http://localhost:8000/delivery/routes/
 - http://localhost:8000/delivery/route_sheet/1/

**New**
1. Fixed http://localhost:8000/delivery/kitchen_count/
2. The other three delivery views are not fixed. Not necessary (same reason as above).