### PR TITLE
Fix #379 Fix #378 Fix #389

### DIFF
--- a/src/note/models.py
+++ b/src/note/models.py
@@ -95,6 +95,8 @@ class NoteFilter(FilterSet):
         ('0', 'No'),
     )
 
+    NOTE_STATUS_UNREAD = IS_READ_CHOICES[2][0]
+
     priority = ChoiceFilter(
         choices=(('', ''),) + Note.PRIORITY_LEVEL,
     )

--- a/src/sous_chef/context_processors.py
+++ b/src/sous_chef/context_processors.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 
 from member.models import Client
-from order.models import Order
-from note.models import Note
+from order.models import Order, ORDER_STATUS_ORDERED
+from note.models import Note, NoteFilter
+import datetime
 
 
 def total(request):
@@ -17,6 +18,13 @@ def total(request):
         'CLIENTS_TOTAL': clients,
         'ORDERS_TOTAL': orders,
         'NOTES_TOTAL': notes,
+        # This is pretty bad separation of concert to puth the following here
+        # But since there is no actual view associated with menu.html (it's
+        # just included is base.html, this is the most DRY way I found
+        'CLIENT_FILTER_DEFAULT_STATUS': Client.ACTIVE,
+        'ORDER_FILTER_DEFAULT_STATUS': ORDER_STATUS_ORDERED,
+        'ORDER_FILTER_DEFAULT_DATE': datetime.datetime.now(),
+        'NOTE_FILTER_DEFAULT_IS_READ': NoteFilter.NOTE_STATUS_UNREAD
     }
 
     return COMMON_CONTEXT

--- a/src/sous_chef/templates/system/menu.html
+++ b/src/sous_chef/templates/system/menu.html
@@ -18,7 +18,7 @@
 </div>
 {% endif %}
 <div class="item">
-    <a class="item" href="{% url 'member:list'%}">{% trans 'Clients' %}
+    <a class="item" href="{% url 'member:list'%}?status={{ CLIENT_FILTER_DEFAULT_STATUS | urlencode }}">{% trans 'Clients' %}
         <div class="ui label">{{ CLIENTS_TOTAL }}</div>
     </a>
 
@@ -30,10 +30,10 @@
             </div>
         </form>
     </div>
-    <a class="item" href="{% url 'order:list' %}">{% trans 'Orders' %}
+    <a class="item" href="{% url 'order:list' %}?status={{ ORDER_FILTER_DEFAULT_STATUS | urlencode }}&delivery_date={{ ORDER_FILTER_DEFAULT_DATE | date:'SHORT_DATE_FORMAT' | urlencode }}">{% trans 'Orders' %}
         <div class="ui label">{{ ORDERS_TOTAL }}</div>
     </a>
-    <a class="item" href="{% url 'note:note_list' %}">{% trans 'Staff Notes' %}
+    <a class="item" href="{% url 'note:note_list' %}?is_read={{ NOTE_FILTER_DEFAULT_IS_READ | urlencode }}">{% trans 'Staff Notes' %}
         <div class="ui label">{{ NOTES_TOTAL }}</div>
     </a>
 

--- a/src/sous_chef/templates/system/menu.html
+++ b/src/sous_chef/templates/system/menu.html
@@ -30,7 +30,7 @@
             </div>
         </form>
     </div>
-    <a class="item" href="{% url 'order:list' %}?status={{ ORDER_FILTER_DEFAULT_STATUS | urlencode }}&delivery_date={{ ORDER_FILTER_DEFAULT_DATE | date:'SHORT_DATE_FORMAT' | urlencode }}">{% trans 'Orders' %}
+    <a class="item" href="{% url 'order:list' %}?status={{ ORDER_FILTER_DEFAULT_STATUS | urlencode }}&amp;delivery_date={{ ORDER_FILTER_DEFAULT_DATE | date:'Y-m-d' | urlencode }}">{% trans 'Orders' %}
         <div class="ui label">{{ ORDERS_TOTAL }}</div>
     </a>
     <a class="item" href="{% url 'note:note_list' %}?is_read={{ NOTE_FILTER_DEFAULT_IS_READ | urlencode }}">{% trans 'Staff Notes' %}


### PR DESCRIPTION
## Fixes #379 #378 #389  by lingxiaoyang
Replaces benoitg's #412

### Changes proposed in this pull request:

Based on #412,
* Merge with dev
* Date is formatted to `Y-m-d` for the filter
* `&` -> `&amp;`

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Check the links on menu: Clients, Orders and Notes. They should have GET parameters now that will be filled in the list filter.

### Deployment notes and migration

none

### New translatable strings

none

### Additional notes

none