### PR TITLE
Fix #601 (route=None in kitchen count)

### DIFF
--- a/src/delivery/locale/en/LC_MESSAGES/django.po
+++ b/src/delivery/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-12-27 17:50+0000\n"
+"POT-Creation-Date: 2017-01-09 20:16+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -58,7 +58,7 @@ msgid "Restore recipe"
 msgstr ""
 
 #: delivery/templates/ingredients.html:82
-#: delivery/templates/kitchen_count.html:96 delivery/templates/routes.html:65
+#: delivery/templates/kitchen_count.html:102 delivery/templates/routes.html:65
 msgid "Back"
 msgstr ""
 
@@ -74,88 +74,93 @@ msgstr ""
 msgid "Kitchen Count Report"
 msgstr ""
 
-#: delivery/templates/kitchen_count.html:22
-msgid "Print the kitchen count report"
+#: delivery/templates/kitchen_count.html:23
+msgid "Download the kitchen count report"
 msgstr ""
 
-#: delivery/templates/kitchen_count.html:23
+#: delivery/templates/kitchen_count.html:24
+#: delivery/templates/kitchen_count.html:28
 #: delivery/templates/kitchen_count_steps.html:18
 msgid "Kitchen Count"
 msgstr ""
 
-#: delivery/templates/kitchen_count.html:26
+#: delivery/templates/kitchen_count.html:27
+msgid "No kitchen count report available"
+msgstr ""
+
+#: delivery/templates/kitchen_count.html:32
 msgid "Download the labels"
 msgstr ""
 
-#: delivery/templates/kitchen_count.html:27
-#: delivery/templates/kitchen_count.html:31
+#: delivery/templates/kitchen_count.html:33
+#: delivery/templates/kitchen_count.html:37
 msgid "Labels"
 msgstr ""
 
-#: delivery/templates/kitchen_count.html:30
+#: delivery/templates/kitchen_count.html:36
 msgid "No labels available"
 msgstr ""
 
-#: delivery/templates/kitchen_count.html:40
+#: delivery/templates/kitchen_count.html:46
 msgid "Component"
 msgstr ""
 
-#: delivery/templates/kitchen_count.html:41
-#: delivery/templates/kitchen_count.html:42
+#: delivery/templates/kitchen_count.html:47
+#: delivery/templates/kitchen_count.html:48
 msgid "TOTAL"
 msgstr ""
 
-#: delivery/templates/kitchen_count.html:41
+#: delivery/templates/kitchen_count.html:47
 #: delivery/templates/route_sheet.html:32
 #: delivery/templates/routes_print.html:33
 msgid "Regular"
 msgstr ""
 
-#: delivery/templates/kitchen_count.html:42
+#: delivery/templates/kitchen_count.html:48
 #: delivery/templates/route_sheet.html:33
 #: delivery/templates/routes_print.html:34
 msgid "Large"
 msgstr ""
 
-#: delivery/templates/kitchen_count.html:43
+#: delivery/templates/kitchen_count.html:49
 msgid "Dish today"
 msgstr ""
 
-#: delivery/templates/kitchen_count.html:44
+#: delivery/templates/kitchen_count.html:50
 msgid "Ingredients today"
 msgstr ""
 
-#: delivery/templates/kitchen_count.html:63
+#: delivery/templates/kitchen_count.html:69
 msgid "Clashing ingredients"
 msgstr ""
 
-#: delivery/templates/kitchen_count.html:64
-#: delivery/templates/kitchen_count.html:65
+#: delivery/templates/kitchen_count.html:70
+#: delivery/templates/kitchen_count.html:71
 #: delivery/templates/route_sheet.html:53
 #: delivery/templates/routes_print.html:55
 msgid "Qty"
 msgstr ""
 
-#: delivery/templates/kitchen_count.html:64
+#: delivery/templates/kitchen_count.html:70
 msgid "Reg"
 msgstr ""
 
-#: delivery/templates/kitchen_count.html:65
+#: delivery/templates/kitchen_count.html:71
 msgid "Lge"
 msgstr ""
 
-#: delivery/templates/kitchen_count.html:66
+#: delivery/templates/kitchen_count.html:72
 #: delivery/templates/partials/generated_orders.html:12
 #: delivery/templates/route_sheet.html:50
 #: delivery/templates/routes_print.html:52
 msgid "Client"
 msgstr ""
 
-#: delivery/templates/kitchen_count.html:67
+#: delivery/templates/kitchen_count.html:73 delivery/views.py:963
 msgid "Restrictions"
 msgstr ""
 
-#: delivery/templates/kitchen_count.html:99
+#: delivery/templates/kitchen_count.html:105
 msgid "Next: Organize Routes"
 msgstr ""
 
@@ -168,7 +173,7 @@ msgstr ""
 msgid "Review orders for the day."
 msgstr ""
 
-#: delivery/templates/kitchen_count_steps.html:12
+#: delivery/templates/kitchen_count_steps.html:12 delivery/views.py:970
 msgid "Ingredients"
 msgstr ""
 
@@ -266,15 +271,23 @@ msgstr ""
 msgid "Total amount in $CAD."
 msgstr ""
 
-#: delivery/templates/partials/generated_orders.html:39
-msgid "Fix geolocalization."
+#: delivery/templates/partials/generated_orders.html:41
+msgid ""
+"Please fix geolocalization. Otherwise this client will be excluded in the "
+"next steps."
 msgstr ""
 
-#: delivery/templates/partials/generated_orders.html:45
+#: delivery/templates/partials/generated_orders.html:44
+msgid ""
+"Please fix delivery route. Otherwise this client will be excluded in the "
+"next steps."
+msgstr ""
+
+#: delivery/templates/partials/generated_orders.html:50
 msgid "Review or change the status of the order."
 msgstr ""
 
-#: delivery/templates/partials/generated_orders.html:46
+#: delivery/templates/partials/generated_orders.html:51
 msgid "Change the details of the order."
 msgstr ""
 
@@ -353,17 +366,12 @@ msgid "Item"
 msgstr ""
 
 #: delivery/templates/route_sheet.html:54
-#: delivery/templates/routes_print.html:56
-msgid "Include a bill"
+msgid "Bill"
 msgstr ""
 
 #: delivery/templates/route_sheet.html:64
 #: delivery/templates/routes_print.html:66
 msgid "Apt"
-msgstr ""
-
-#: delivery/templates/route_sheet.html:82
-msgid "Bill"
 msgstr ""
 
 #: delivery/templates/route_sheet.html:86
@@ -413,6 +421,14 @@ msgstr ""
 msgid "Print"
 msgstr ""
 
+#: delivery/templates/routes_print.html:56
+msgid "Include a bill"
+msgstr ""
+
+#: delivery/tests.py:915
+msgid "Main Dish"
+msgstr ""
+
 #: delivery/urls.py:10
 msgid "^order/$"
 msgstr ""
@@ -447,21 +463,41 @@ msgid "^kitchen_count/(?P<year>\\d{4})/(?P<month>\\d{2})/(?P<day>\\d+)/$"
 msgstr ""
 
 #: delivery/urls.py:20
+msgid "^viewDownloadKitchenCount/$"
+msgstr ""
+
+#: delivery/urls.py:22
 msgid "^viewMealLabels/$"
 msgstr ""
 
-#: delivery/urls.py:21
+#: delivery/urls.py:23
 msgid "^route_sheet/(?P<id>\\d+)/$"
 msgstr ""
 
-#: delivery/urls.py:23
+#: delivery/urls.py:25
 msgid "^getDailyOrders/$"
 msgstr ""
 
-#: delivery/urls.py:24
+#: delivery/urls.py:26
 msgid "^refresh_orders/$"
 msgstr ""
 
-#: delivery/urls.py:26
+#: delivery/urls.py:28
 msgid "^save_route/$"
+msgstr ""
+
+#: delivery/views.py:958
+msgid "LARGE"
+msgstr ""
+
+#: delivery/views.py:975
+msgid "Preparation"
+msgstr ""
+
+#: delivery/views.py:987
+msgid "Sides clashes"
+msgstr ""
+
+#: delivery/views.py:1016
+msgid "Other restrictions"
 msgstr ""

--- a/src/delivery/locale/fr/LC_MESSAGES/django.po
+++ b/src/delivery/locale/fr/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-12-27 17:50+0000\n"
+"POT-Creation-Date: 2017-01-09 20:16+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: PascalPriori <pascal.priori@savoirfairelinux.com>, 2016\n"
 "Language-Team: French (https://www.transifex.com/savoirfairelinux/"
@@ -64,7 +64,7 @@ msgid "Restore recipe"
 msgstr "Restaurer la recette"
 
 #: delivery/templates/ingredients.html:82
-#: delivery/templates/kitchen_count.html:96 delivery/templates/routes.html:65
+#: delivery/templates/kitchen_count.html:102 delivery/templates/routes.html:65
 msgid "Back"
 msgstr "Précédent"
 
@@ -80,92 +80,99 @@ msgstr "Inventaire des repas"
 msgid "Kitchen Count Report"
 msgstr "Inventaire des repas"
 
-#: delivery/templates/kitchen_count.html:22
+#: delivery/templates/kitchen_count.html:23
 #, fuzzy
 #| msgid "Print the kitchen count."
-msgid "Print the kitchen count report"
+msgid "Download the kitchen count report"
 msgstr "Imprimer l'inventaire des repas."
 
-#: delivery/templates/kitchen_count.html:23
+#: delivery/templates/kitchen_count.html:24
+#: delivery/templates/kitchen_count.html:28
 #: delivery/templates/kitchen_count_steps.html:18
 msgid "Kitchen Count"
 msgstr "Inventaire des repas"
 
-#: delivery/templates/kitchen_count.html:26
+#: delivery/templates/kitchen_count.html:27
+#, fuzzy
+#| msgid "Kitchen Count report"
+msgid "No kitchen count report available"
+msgstr "Inventaire des repas"
+
+#: delivery/templates/kitchen_count.html:32
 msgid "Download the labels"
 msgstr ""
 
-#: delivery/templates/kitchen_count.html:27
-#: delivery/templates/kitchen_count.html:31
+#: delivery/templates/kitchen_count.html:33
+#: delivery/templates/kitchen_count.html:37
 msgid "Labels"
 msgstr ""
 
-#: delivery/templates/kitchen_count.html:30
+#: delivery/templates/kitchen_count.html:36
 msgid "No labels available"
 msgstr ""
 
-#: delivery/templates/kitchen_count.html:40
+#: delivery/templates/kitchen_count.html:46
 msgid "Component"
 msgstr "Composant"
 
-#: delivery/templates/kitchen_count.html:41
-#: delivery/templates/kitchen_count.html:42
+#: delivery/templates/kitchen_count.html:47
+#: delivery/templates/kitchen_count.html:48
 msgid "TOTAL"
 msgstr "TOTAL"
 
-#: delivery/templates/kitchen_count.html:41
+#: delivery/templates/kitchen_count.html:47
 #: delivery/templates/route_sheet.html:32
 #: delivery/templates/routes_print.html:33
 msgid "Regular"
 msgstr "Régulier"
 
-#: delivery/templates/kitchen_count.html:42
+#: delivery/templates/kitchen_count.html:48
 #: delivery/templates/route_sheet.html:33
 #: delivery/templates/routes_print.html:34
 msgid "Large"
 msgstr "Grand"
 
-#: delivery/templates/kitchen_count.html:43
+#: delivery/templates/kitchen_count.html:49
 msgid "Dish today"
 msgstr "Plat du jour"
 
-#: delivery/templates/kitchen_count.html:44
+#: delivery/templates/kitchen_count.html:50
 msgid "Ingredients today"
 msgstr "Ingrédients du jour"
 
-#: delivery/templates/kitchen_count.html:63
+#: delivery/templates/kitchen_count.html:69
 #, fuzzy
 #| msgid "Pick ingredients"
 msgid "Clashing ingredients"
 msgstr "Sélectionner les ingrédients"
 
-#: delivery/templates/kitchen_count.html:64
-#: delivery/templates/kitchen_count.html:65
+#: delivery/templates/kitchen_count.html:70
+#: delivery/templates/kitchen_count.html:71
 #: delivery/templates/route_sheet.html:53
 #: delivery/templates/routes_print.html:55
 msgid "Qty"
 msgstr "Qte"
 
-#: delivery/templates/kitchen_count.html:64
+#: delivery/templates/kitchen_count.html:70
 msgid "Reg"
 msgstr "Rég"
 
-#: delivery/templates/kitchen_count.html:65
+#: delivery/templates/kitchen_count.html:71
 msgid "Lge"
 msgstr "Lrg"
 
-#: delivery/templates/kitchen_count.html:66
+#: delivery/templates/kitchen_count.html:72
 #: delivery/templates/partials/generated_orders.html:12
 #: delivery/templates/route_sheet.html:50
 #: delivery/templates/routes_print.html:52
 msgid "Client"
 msgstr "Client"
 
-#: delivery/templates/kitchen_count.html:67
+#: delivery/templates/kitchen_count.html:73 delivery/views.py:963
 msgid "Restrictions"
 msgstr "Restrictions"
 
-#: delivery/templates/kitchen_count.html:99
+#: delivery/templates/kitchen_count.html:105
 msgid "Next: Organize Routes"
 msgstr "Suivant: Organiser les itinéraires"
 
@@ -178,7 +185,7 @@ msgstr "Réviser les commandes"
 msgid "Review orders for the day."
 msgstr "Réviser les commandes du jour."
 
-#: delivery/templates/kitchen_count_steps.html:12
+#: delivery/templates/kitchen_count_steps.html:12 delivery/views.py:970
 msgid "Ingredients"
 msgstr "Ingrédients"
 
@@ -286,15 +293,23 @@ msgstr "Montant"
 msgid "Total amount in $CAD."
 msgstr ""
 
-#: delivery/templates/partials/generated_orders.html:39
-msgid "Fix geolocalization."
+#: delivery/templates/partials/generated_orders.html:41
+msgid ""
+"Please fix geolocalization. Otherwise this client will be excluded in the "
+"next steps."
 msgstr ""
 
-#: delivery/templates/partials/generated_orders.html:45
+#: delivery/templates/partials/generated_orders.html:44
+msgid ""
+"Please fix delivery route. Otherwise this client will be excluded in the "
+"next steps."
+msgstr ""
+
+#: delivery/templates/partials/generated_orders.html:50
 msgid "Review or change the status of the order."
 msgstr ""
 
-#: delivery/templates/partials/generated_orders.html:46
+#: delivery/templates/partials/generated_orders.html:51
 msgid "Change the details of the order."
 msgstr ""
 
@@ -381,18 +396,13 @@ msgid "Item"
 msgstr "Article"
 
 #: delivery/templates/route_sheet.html:54
-#: delivery/templates/routes_print.html:56
-msgid "Include a bill"
+msgid "Bill"
 msgstr ""
 
 #: delivery/templates/route_sheet.html:64
 #: delivery/templates/routes_print.html:66
 msgid "Apt"
 msgstr "App"
-
-#: delivery/templates/route_sheet.html:82
-msgid "Bill"
-msgstr ""
 
 #: delivery/templates/route_sheet.html:86
 #: delivery/templates/routes_print.html:83
@@ -453,6 +463,16 @@ msgstr ""
 msgid "Print"
 msgstr "Imprimer"
 
+#: delivery/templates/routes_print.html:56
+msgid "Include a bill"
+msgstr ""
+
+#: delivery/tests.py:915
+#, fuzzy
+#| msgid "Main dish"
+msgid "Main Dish"
+msgstr "Plat principal"
+
 #: delivery/urls.py:10
 msgid "^order/$"
 msgstr "^order/$"
@@ -491,32 +511,58 @@ msgid "^kitchen_count/(?P<year>\\d{4})/(?P<month>\\d{2})/(?P<day>\\d+)/$"
 msgstr "^kitchen_count/(?P<year>\\d{4})/(?P<month>\\d{2})/(?P<day>\\d+)/$"
 
 #: delivery/urls.py:20
+#, fuzzy
+#| msgid "^kitchen_count/$"
+msgid "^viewDownloadKitchenCount/$"
+msgstr "^kitchen_count/$"
+
+#: delivery/urls.py:22
 msgid "^viewMealLabels/$"
 msgstr ""
 
-#: delivery/urls.py:21
+#: delivery/urls.py:23
 msgid "^route_sheet/(?P<id>\\d+)/$"
 msgstr "^route_sheet/(?P<id>\\d+)/$"
 
-#: delivery/urls.py:23
+#: delivery/urls.py:25
 msgid "^getDailyOrders/$"
 msgstr "^getDailyOrders/$"
 
-#: delivery/urls.py:24
+#: delivery/urls.py:26
 msgid "^refresh_orders/$"
 msgstr "^refresh_orders/$"
 
-#: delivery/urls.py:26
+#: delivery/urls.py:28
 #, fuzzy
 #| msgid "^saveRoute/$"
 msgid "^save_route/$"
 msgstr "^saveRoute/$"
 
+#: delivery/views.py:958
+msgid "LARGE"
+msgstr ""
+
+#: delivery/views.py:975
+msgid "Preparation"
+msgstr "Préparation"
+
+#: delivery/views.py:987
+msgid "Sides clashes"
+msgstr ""
+
+#: delivery/views.py:1016
+#, fuzzy
+#| msgid "Restrictions"
+msgid "Other restrictions"
+msgstr "Restrictions"
+
+#, fuzzy
+#~| msgid "Delivery Date"
+#~ msgid "Fix delivery route."
+#~ msgstr "Date de livraison"
+
 #~ msgid "Clashing"
 #~ msgstr "En conflit"
-
-#~ msgid "Preparation"
-#~ msgstr "Préparation"
 
 #~ msgid "Print the Report"
 #~ msgstr "Imprimer l'inventaire des repas"

--- a/src/delivery/templates/partials/generated_orders.html
+++ b/src/delivery/templates/partials/generated_orders.html
@@ -29,15 +29,20 @@
   <tbody>
     {% for order in orders %}
       {% if order.status == 'O' %}
-      <tr {% if not order.client.is_geolocalized %}class="error"{% endif %}>
+      <tr {% if not order.client.is_geolocalized or not order.client.route %}class="error"{% endif %}>
         <td class="center aligned"><strong><i class="hashtag icon"></i>{{order.id}}</strong></td>
         <td><a href="{% url 'member:client_information' pk=order.client.id %}">{{order.client.member}}</a>
         </td>
         <td>{{order.delivery_date}}</td>
-        <td>{{order.client.route}}
+        <td>
+          {% if order.client.route %}
+            {{order.client.route}}
             {% if not order.client.is_geolocalized %}
-            <a href="{% url 'member:member_update_address_information' pk=order.client.id %}" title="{% trans 'Fix geolocalization.' %}"><i class="warning sign red icon"></i></a>
+            <a href="{% url 'member:member_update_address_information' pk=order.client.id %}" title="{% trans 'Please fix geolocalization. Otherwise this client will be excluded in the next steps.' %}"><i class="warning sign red icon"></i></a>
             {% endif %}
+          {% else %}
+            <a href="{% url 'member:member_update_address_information' pk=order.client.id %}" title="{% trans 'Please fix delivery route. Otherwise this client will be excluded in the next steps.' %}"><i class="warning sign red icon"></i></a>
+          {% endif %}
         </td>
         <td class="center aligned">{{order.get_status_display}}</td>
         <td class="center aligned"><i class="dollar icon"></i>{{order.price}}</td>
@@ -46,7 +51,7 @@
             {% if can_edit_data %}<a class="ui basic icon button" title="{% trans 'Change the details of the order.' %}" href="{% url 'order:update' pk=order.id %}"><i class="icon edit"></i></a>{% endif %}
         </td>
       </tr>
-    {% endif %}
+      {% endif %}
     {% endfor %}
   </tbody>
 </table>


### PR DESCRIPTION
## Fix #601 by lingxiaoyang

### Changes proposed in this pull request:

* Consider when `client.route is None`, when sorting the generated orders.
* If a client has null route, the corresponding field will show a warning sign, linking to client update form. (originally, the warning sign is shown when a client is not geolocalized.)
![image](https://cloud.githubusercontent.com/assets/8630726/21508527/d0ca9a34-cc4f-11e6-8b66-02823a0b6acf.png)

* New unit test of the display of warning signs.
* New unit test of the entire kitchen count procedure, to test if `route=None` clients are excluded in each step.
* Fix the problem that `route=None` clients are not excluded in `clashing ingredients` table.
* Also exclude all non-geolocalized clients in next steps of the kitchen count.


### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

1. Generate today's delivery orders.
2. Choose a client, go to Django admin, set route to null.
3. Follow the steps in kitchen count. This client should now be excluded in the procedure.
4. For ungeolocalized clients (client.member.address.latitude/longitude is None), there's a warning in organize route page, but they are included in the procedure.

### Deployment notes and migration

none

### New translatable strings

 - [x] included

### Additional notes

none
