### PR TITLE
Fixed #608: Semantic UI dropdown behavior

### DIFF
--- a/src/frontend/js/global.js
+++ b/src/frontend/js/global.js
@@ -16,7 +16,8 @@ $(function() {
     $('.ui.accordion').accordion();
     $('.ui.dropdown').dropdown({
         transition: 'drop',
-        fullTextSearch: 'exact'
+        fullTextSearch: 'exact',
+        forceSelection: false
     });
 
     $('.ui.calendar').calendar({


### PR DESCRIPTION
## Fixes #608  by lingxiaoyang

### Changes proposed in this pull request:

* Set `forceSelection = false` by default for Semantic UI dropdowns

See https://github.com/Semantic-Org/Semantic-UI/issues/4546

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Follow the steps described in #608 .

### Deployment notes and migration
none

### New translatable strings

none

### Additional notes

none
