### PR TITLE
Fixed #615 -- Allowed to filter notes by date

### DIFF
--- a/src/note/locale/en/LC_MESSAGES/django.po
+++ b/src/note/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-12-16 22:14+0000\n"
+"POT-Creation-Date: 2017-01-06 21:40+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -37,7 +37,7 @@ msgstr ""
 msgid "Author"
 msgstr ""
 
-#: note/models.py:49
+#: note/models.py:49 note/templates/notes_list.html:60
 msgid "Date"
 msgstr ""
 
@@ -50,7 +50,7 @@ msgstr ""
 msgid "Client"
 msgstr ""
 
-#: note/models.py:108
+#: note/models.py:110
 msgid "Search by name"
 msgstr ""
 
@@ -95,11 +95,11 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: note/templates/notes_client_list.html:49 note/templates/notes_list.html:61
+#: note/templates/notes_client_list.html:49 note/templates/notes_list.html:72
 msgid "Reset"
 msgstr ""
 
-#: note/templates/notes_client_list.html:50 note/templates/notes_list.html:62
+#: note/templates/notes_client_list.html:50 note/templates/notes_list.html:73
 msgid "Search"
 msgstr ""
 
@@ -107,11 +107,11 @@ msgstr ""
 msgid "New Note"
 msgstr ""
 
-#: note/templates/notes_client_list.html:65 note/templates/notes_list.html:74
+#: note/templates/notes_client_list.html:65 note/templates/notes_list.html:83
 msgid "Mark as unread"
 msgstr ""
 
-#: note/templates/notes_client_list.html:68 note/templates/notes_list.html:77
+#: note/templates/notes_client_list.html:68 note/templates/notes_list.html:86
 msgid "Mark as read"
 msgstr ""
 
@@ -127,7 +127,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: note/templates/notes_list.html:108
+#: note/templates/notes_list.html:117
 msgid "of"
 msgstr ""
 
@@ -143,6 +143,6 @@ msgstr ""
 msgid "^unread/(?P<id>\\d+)/$"
 msgstr ""
 
-#: note/views.py:94
+#: note/views.py:98
 msgid "The note has been created."
 msgstr ""

--- a/src/note/locale/fr/LC_MESSAGES/django.po
+++ b/src/note/locale/fr/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-12-16 22:14+0000\n"
+"POT-Creation-Date: 2017-01-06 21:40+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: PascalPriori <pascal.priori@savoirfairelinux.com>, 2016\n"
 "Language-Team: French (https://www.transifex.com/savoirfairelinux/"
@@ -39,7 +39,7 @@ msgstr "Note"
 msgid "Author"
 msgstr "Auteur"
 
-#: note/models.py:49
+#: note/models.py:49 note/templates/notes_list.html:60
 msgid "Date"
 msgstr "Date"
 
@@ -52,7 +52,7 @@ msgstr "lu"
 msgid "Client"
 msgstr "Client"
 
-#: note/models.py:108
+#: note/models.py:110
 msgid "Search by name"
 msgstr "Recherche par nom"
 
@@ -97,11 +97,11 @@ msgstr ""
 msgid "Priority"
 msgstr "Priorité"
 
-#: note/templates/notes_client_list.html:49 note/templates/notes_list.html:61
+#: note/templates/notes_client_list.html:49 note/templates/notes_list.html:72
 msgid "Reset"
 msgstr "Réinitialiser"
 
-#: note/templates/notes_client_list.html:50 note/templates/notes_list.html:62
+#: note/templates/notes_client_list.html:50 note/templates/notes_list.html:73
 msgid "Search"
 msgstr "Recherche"
 
@@ -111,11 +111,11 @@ msgstr "Recherche"
 msgid "New Note"
 msgstr "Note"
 
-#: note/templates/notes_client_list.html:65 note/templates/notes_list.html:74
+#: note/templates/notes_client_list.html:65 note/templates/notes_list.html:83
 msgid "Mark as unread"
 msgstr "Marquer comme non lu"
 
-#: note/templates/notes_client_list.html:68 note/templates/notes_list.html:77
+#: note/templates/notes_client_list.html:68 note/templates/notes_list.html:86
 msgid "Mark as read"
 msgstr "Marquer comme lu"
 
@@ -131,7 +131,7 @@ msgstr ""
 msgid "Name"
 msgstr "Nom"
 
-#: note/templates/notes_list.html:108
+#: note/templates/notes_list.html:117
 msgid "of"
 msgstr ""
 
@@ -147,6 +147,6 @@ msgstr "^lu/(?P<id>\\d+)/$"
 msgid "^unread/(?P<id>\\d+)/$"
 msgstr "^nonlu/(?P<id>\\d+)/$"
 
-#: note/views.py:94
+#: note/views.py:98
 msgid "The note has been created."
 msgstr ""

--- a/src/note/models.py
+++ b/src/note/models.py
@@ -1,6 +1,6 @@
 from django.db import models
 from django.db.models import Q
-from django_filters import FilterSet, ChoiceFilter, BooleanFilter, MethodFilter
+from django_filters import ChoiceFilter, DateFilter, FilterSet, MethodFilter
 from django.utils.translation import ugettext_lazy as _
 from django.contrib.auth.models import User
 from django.utils import timezone
@@ -110,9 +110,11 @@ class NoteFilter(FilterSet):
         label=_('Search by name')
     )
 
+    date = DateFilter(lookup_expr='date')
+
     class Meta:
         model = Note
-        fields = ['priority', 'is_read']
+        fields = ['priority', 'is_read', 'date', ]
 
     @staticmethod
     def filter_search(queryset, value):

--- a/src/note/templates/notes_list.html
+++ b/src/note/templates/notes_list.html
@@ -56,6 +56,17 @@
               {{ filter.form.is_read|alter_field_class:'ui dropdown' }}
             </div>
           </div>
+          <div class="field">
+              <label>{% trans 'Date' %}</label>
+              <div class="field">
+                  <div class="ui calendar" id="note_date">
+                      <div class="ui input left icon">
+                            <i class="calendar icon"></i>
+                            {{ filter.form.date }}
+                      </div>
+                  </div>
+              </div>
+          </div>
         </div>
         <div class="field">
           <a href="{{ request.path }}?display={{ display }}" class="ui button">{% trans "Reset" %}</a>

--- a/src/sous_chef/templates/system/menu.html
+++ b/src/sous_chef/templates/system/menu.html
@@ -8,7 +8,7 @@
     </a>
 </div>
 {% if request.user %}
-<div class="item loggedin-user">    
+<div class="item loggedin-user">
     <a href="{% url 'avatar_change' %}">
       {% avatar user 80 class="ui tiny left floated circular image" id="user_avatar" %}
     </a>
@@ -36,7 +36,7 @@
     <a class="item" href="{% url 'order:list' %}?status={{ ORDER_FILTER_DEFAULT_STATUS | urlencode }}&amp;delivery_date={{ ORDER_FILTER_DEFAULT_DATE | date:'Y-m-d' | urlencode }}">{% trans 'Orders' %}
         <div class="ui label">{{ ORDERS_TOTAL }}</div>
     </a>
-    <a class="item" href="{% url 'note:note_list' %}?is_read={{ NOTE_FILTER_DEFAULT_IS_READ | urlencode }}">{% trans 'Staff Notes' %}
+    <a class="item" href="{% url 'note:note_list' %}?is_read={{ NOTE_FILTER_DEFAULT_IS_READ | urlencode }}&amp;date={% now 'Y-m-d' %}">{% trans 'Staff Notes' %}
         <div class="ui label">{{ NOTES_TOTAL }}</div>
     </a>
 


### PR DESCRIPTION
## Fixes #615 by ellmetha

### Changes proposed in this pull request:

* Add a filter in the note list allowing to filter notes by date

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Go to the "Staff notes" section an try to filter existing notes.

### New translatable strings

- [X] I have updated .po files with new strings (see http://goo.gl/kfBO7N)

