### PR TITLE
Fixed #616: add route client on dashboard, with unit test

### DIFF
--- a/src/frontend/scss/admin/admin.scss
+++ b/src/frontend/scss/admin/admin.scss
@@ -123,7 +123,8 @@ p.signup, p.dashboard {
   display: flex;
   flex-direction: column;
   justify-content: center;
-  min-height: 171px;
+  height: 171px;
+  overflow-y: auto;
 }
 
 .ui.dashboard.statistic .value {

--- a/src/page/locale/en/LC_MESSAGES/django.po
+++ b/src/page/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-12-16 22:14+0000\n"
+"POT-Creation-Date: 2017-01-12 16:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -62,16 +62,15 @@ msgid ""
 msgstr ""
 
 #: page/templates/pages/home.html:64
-msgid "Any Header"
+msgid "Routes"
 msgstr ""
 
-#: page/templates/pages/home.html:72
-msgid "Downloads"
-msgstr ""
-
-#: page/templates/pages/home.html:77
-msgid "Footer"
-msgstr ""
+#: page/templates/pages/home.html:86
+#, python-format
+msgid "%(count)s route."
+msgid_plural "%(count)s routes."
+msgstr[0] ""
+msgstr[1] ""
 
 #: page/templates/registration/login.html:8
 #: page/templates/registration/login.html:37

--- a/src/page/locale/fr/LC_MESSAGES/django.po
+++ b/src/page/locale/fr/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-12-16 22:14+0000\n"
+"POT-Creation-Date: 2017-01-12 16:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: PascalPriori <pascal.priori@savoirfairelinux.com>, 2016\n"
 "Language-Team: French (https://www.transifex.com/savoirfairelinux/"
@@ -64,16 +64,15 @@ msgid ""
 msgstr ""
 
 #: page/templates/pages/home.html:64
-msgid "Any Header"
+msgid "Routes"
 msgstr ""
 
-#: page/templates/pages/home.html:72
-msgid "Downloads"
-msgstr "Téléchargements"
-
-#: page/templates/pages/home.html:77
-msgid "Footer"
-msgstr "Pied de page"
+#: page/templates/pages/home.html:86
+#, python-format
+msgid "%(count)s route."
+msgid_plural "%(count)s routes."
+msgstr[0] ""
+msgstr[1] ""
 
 #: page/templates/registration/login.html:8
 #: page/templates/registration/login.html:37
@@ -87,6 +86,12 @@ msgstr "Se connecter à son compte"
 #: page/templates/registration/login.html:48
 msgid "Connect"
 msgstr "Connexion"
+
+#~ msgid "Downloads"
+#~ msgstr "Téléchargements"
+
+#~ msgid "Footer"
+#~ msgstr "Pied de page"
 
 #~ msgid "Dashboard"
 #~ msgstr "Tableau de bord"

--- a/src/page/templates/pages/home.html
+++ b/src/page/templates/pages/home.html
@@ -61,20 +61,30 @@
             <div class="dashboard-stat column">
               <div class="ui segments">
                 <div class="ui segment">
-                  <h3 class="ui blue header">{% trans "Any Header" %}</h3>
+                  <h3 class="ui blue header">{% trans "Routes" %}</h3>
                 </div>
-                <div class="ui secondary blue inverted dashboard center aligned segment">
-                  <div class="ui dashboard statistic">
-                    <div class="value">
-                      5,550
-                    </div>
-                    <div class="label">
-                      {% trans "Downloads" %}
-                    </div>
+                <div class="ui secondary blue inverted dashboard left aligned segment" style="justify-content: flex-start">
+                  <div style="padding-bottom:14px">
+                    <table class="ui very compact table">
+                      <tbody>
+                    {% for route_name, num_clients in routes %}
+                        <tr>
+                          <td>
+                            {{ route_name }}
+                          </td>
+                          <td>
+                            <span class="ui blue basic label">{{ num_clients }}</span>
+                          </td>
+                        </tr>
+                    {% endfor %}
+                      </tbody>
+                    </table>
                   </div>
                 </div>
                 <div class="ui segment">
-                  <p>{% trans "Footer" %}</p>
+                  <p>
+                    {% blocktrans count count=routes|length %}{{ count }} route.{% plural %}{{ count }} routes.{% endblocktrans %}
+                  </p>
                 </div>
               </div>
             </div>

--- a/src/page/tests.py
+++ b/src/page/tests.py
@@ -3,6 +3,9 @@ from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse_lazy
 from django.core.urlresolvers import reverse
 
+from member.factories import RouteFactory, ClientFactory
+from member.models import Client
+
 
 class HomeViewTestCase(TestCase):
 
@@ -42,3 +45,37 @@ class HomeViewTestCase(TestCase):
             reverse('page:login') + '?next=/p/home',
             status_code=302
         )
+
+    def test_route_client_counts(self):
+        """
+        On dashboard, routes shouly only include active and paused clients.
+        """
+        self.client.login(
+            username=self.admin.username,
+            password="test"
+        )
+        route = RouteFactory()
+        counts = (
+            (Client.PENDING, 1),
+            (Client.ACTIVE, 2),
+            (Client.PAUSED, 4),
+            (Client.STOPNOCONTACT, 8),
+            (Client.STOPCONTACT, 16),
+            (Client.DECEASED, 32),
+        )
+        for status, count in counts:
+            ClientFactory.create_batch(
+                count,
+                status=status,
+                route=route
+            )
+        response = self.client.get(
+            reverse_lazy(
+                'page:home'
+            ),
+            follow=False
+        )
+        self.assertEqual(response.status_code, 200)
+        routes = response.context['routes']
+        self.assertEqual(routes[0][0], route.name)
+        self.assertEqual(routes[0][1], 2 + 4)


### PR DESCRIPTION
## Fixes #616 by lingxiaoyang

### Changes proposed in this pull request:

* Show route info on dashboard. The number shows the number of active and pause clients on this route.

![image](https://cloud.githubusercontent.com/assets/8630726/21898445/eb49f068-d8ba-11e6-855e-1f3a86011866.png)
![image](https://cloud.githubusercontent.com/assets/8630726/21898556/2ee9a354-d8bb-11e6-8248-0dc63e67b33a.png)

* Unit test: the number of clients shown.

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Go to dashboard. The third dashboard block should now be replaced.

### Deployment notes and migration

none

### New translatable strings

- [x] If applicable, I have included updated .po files with new strings (see http://goo.gl/kfBO7N)

### Additional notes
none
