### PR TITLE
Fixed #620: printing map and directions

### DIFF
--- a/src/delivery/locale/en/LC_MESSAGES/django.po
+++ b/src/delivery/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-01-11 15:12+0000\n"
+"POT-Creation-Date: 2017-01-13 20:39+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -198,6 +198,8 @@ msgid "Organize the delivery route"
 msgstr ""
 
 #: delivery/templates/organize_route.html:21
+#: delivery/templates/organize_route.html:64
+#: delivery/templates/organize_route.html:75
 msgid "Delivery route"
 msgstr ""
 
@@ -225,6 +227,27 @@ msgstr ""
 #: delivery/templates/organize_route.html:54
 #: delivery/templates/route_sheet.html:102
 msgid "View routes"
+msgstr ""
+
+#: delivery/templates/organize_route.html:79
+#: delivery/templates/routes_print.html:23
+msgid "Print"
+msgstr ""
+
+#: delivery/templates/organize_route.html:100
+msgid "Route Sequence"
+msgstr ""
+
+#: delivery/templates/organize_route.html:105
+msgid "Client Name"
+msgstr ""
+
+#: delivery/templates/organize_route.html:106
+msgid "Address"
+msgstr ""
+
+#: delivery/templates/organize_route.html:124
+msgid "Directions"
 msgstr ""
 
 #: delivery/templates/partials/generated_orders.html:9
@@ -425,15 +448,11 @@ msgstr ""
 msgid "Number of orders on this route"
 msgstr ""
 
-#: delivery/templates/routes_print.html:23
-msgid "Print"
-msgstr ""
-
 #: delivery/templates/routes_print.html:56
 msgid "Include a bill"
 msgstr ""
 
-#: delivery/tests.py:915
+#: delivery/tests.py:916
 msgid "Main Dish"
 msgstr ""
 

--- a/src/delivery/locale/fr/LC_MESSAGES/django.po
+++ b/src/delivery/locale/fr/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-01-11 15:12+0000\n"
+"POT-Creation-Date: 2017-01-13 20:39+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: PascalPriori <pascal.priori@savoirfairelinux.com>, 2016\n"
 "Language-Team: French (https://www.transifex.com/savoirfairelinux/"
@@ -212,6 +212,8 @@ msgid "Organize the delivery route"
 msgstr "Organiser les itinéraires de livraison."
 
 #: delivery/templates/organize_route.html:21
+#: delivery/templates/organize_route.html:64
+#: delivery/templates/organize_route.html:75
 #, fuzzy
 #| msgid "Delivery Date"
 msgid "Delivery route"
@@ -246,6 +248,29 @@ msgstr ""
 #| msgid "View Order"
 msgid "View routes"
 msgstr "Voir la commande"
+
+#: delivery/templates/organize_route.html:79
+#: delivery/templates/routes_print.html:23
+msgid "Print"
+msgstr "Imprimer"
+
+#: delivery/templates/organize_route.html:100
+#, fuzzy
+#| msgid "Route sheet"
+msgid "Route Sequence"
+msgstr ""
+
+#: delivery/templates/organize_route.html:105
+msgid "Client Name"
+msgstr "Nom du Client"
+
+#: delivery/templates/organize_route.html:106
+msgid "Address"
+msgstr "Adresse"
+
+#: delivery/templates/organize_route.html:124
+msgid "Directions"
+msgstr "Directions"
 
 #: delivery/templates/partials/generated_orders.html:9
 msgid "Order"
@@ -467,15 +492,11 @@ msgstr ""
 msgid "Number of orders on this route"
 msgstr ""
 
-#: delivery/templates/routes_print.html:23
-msgid "Print"
-msgstr "Imprimer"
-
 #: delivery/templates/routes_print.html:56
 msgid "Include a bill"
 msgstr ""
 
-#: delivery/tests.py:915
+#: delivery/tests.py:916
 #, fuzzy
 #| msgid "Main dish"
 msgid "Main Dish"

--- a/src/delivery/templates/organize_route.html
+++ b/src/delivery/templates/organize_route.html
@@ -25,7 +25,7 @@
 </div>
 
 <div class="ui basic segment no-print">
-    <a href="javascript:window.print()" class="ui labeled icon right pink basic big button" title="{% trans 'Print the map and directions' %}">
+    <a href="javascript:printMapAndItinerary()" class="ui labeled icon right pink basic big button" title="{% trans 'Print the map and directions' %}">
         <i class="print icon"></i>{% trans 'Map and Directions' %}
     </a>
 </div>
@@ -53,13 +53,94 @@
   <i class="chevron left icon"></i>{% trans 'View routes' %}
 </a>
 
+
+<script type="x-tmpl-mustache" id="print-template">
+  {% comment %}The print window is managed by JavaScript (using Mustache template system). Below is the page template.{% endcomment %}
+  <!DOCTYPE html>
+  <html>
+    <head>
+      <title>{% trans "Delivery route" %}: {{ route.name }} - {% now "j F Y" %}</title>
+      <meta charset="utf-8">
+      <link href="http://netdna.bootstrapcdn.com/font-awesome/4.0.0/css/font-awesome.css" rel="stylesheet">
+      {% leaflet_css %}
+      <link href="{% static 'css/main.min.css' %}" type="text/css" rel="stylesheet">
+      <style>
+        hr {margin-top:2em;margin-bottom:2em}
+        #directions td:last-child {white-space:nowrap}
+      </style>
+    </head>
+    <body style="width: {% verbatim %}{{ map_width }}{% endverbatim %}px;" other=" height:100%; overflow:auto">
+      <h1>{% trans "Delivery route" %}: {{ route.name }}</h1>
+      <h4>{% now "j F Y" %}</h4>
+      <br/>
+      <div>
+        <button class="no-print" onclick="window.print()">{% trans 'Print' %}</button>
+      </div>
+
+      {% verbatim %}
+      <div style="height: {{ map_height }}px; width: {{ map_width }}px; position:relative; overflow:hidden">
+        <div style="position:absolute; left: {{ pane_left }}px; top: {{ pane_top }}px;">
+        {{#map_imgs}}
+          <img src="{{ src }}" style="position:absolute; top: {{ top }}px; left: {{ left }}px">
+        {{/map_imgs}}
+
+        {{{ map_route_svg }}}
+
+        {{#routes}}
+          <div style="position:absolute; top:0; left:0">{{{ marker_html }}}</div>
+        {{/routes}}
+        </div>
+      </div>
+      {% endverbatim %}
+
+      <hr />
+
+      <h2>{% trans 'Route Sequence' %}</h2>
+      <table style="width: 100%">
+        <thead>
+          <tr>
+            <th></th>
+            <th style="text-align:left">{% trans 'Client Name' %}</th>
+            <th style="text-align:left">{% trans 'Address' %}</th>
+          </tr>
+        </thead>
+        {% verbatim %}
+        <tbody>
+          {{#routes}}
+          <tr>
+            <th>{{ client_order }}</th>
+            <td>{{ client_name }}</td>
+            <td>{{ client_address }}</td>
+          </tr>
+          {{/routes}}
+        </tbody>
+        {% endverbatim %}
+      </table>
+
+      <hr />
+
+      <h2>{% trans 'Directions' %}</h2>
+      {% verbatim %}
+      <h4>{{ distance_and_time }}</h4>
+      {% endverbatim %}
+      <table style="width: 100%" id="directions">
+        {% verbatim %}
+        {{{ directions_table }}}
+        {% endverbatim %}
+      </table>
+      <br/>
+    </body>
+  </html>
+</script>
 {% endblock %}
 
 {% block extrajs %}
     {% leaflet_js %}
     {% if debug %}
         <script src="{% static 'js/leaflet.js' %}" type="application/javascript"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/mustache.js/2.3.0/mustache.js"></script>
     {% else %}
         <script src="{% static 'js/leaflet.min.js' %}" type="application/javascript"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/mustache.js/2.3.0/mustache.min.js"></script>
     {% endif %}
 {% endblock %}

--- a/src/frontend/scss/admin/admin.scss
+++ b/src/frontend/scss/admin/admin.scss
@@ -282,6 +282,10 @@ ul.doughnut-legend {
   max-height:400px;
 }
 
+.leaflet-routing-icon {
+    background-image: url('/static/images/vendor/leaflet-routing/leaflet.routing.icons.svg')!important;
+}
+
 /* Avatars */
 .list-avatars {
   margin-bottom:1em;

--- a/src/frontend/scss/base/print.scss
+++ b/src/frontend/scss/base/print.scss
@@ -1,6 +1,8 @@
 .print-only {display:none!important}
 
 @media only print {
+    html, body {background:none!important}
+
     .ui.left.fixed.vertical.inverted.menu
     {display:none;}
 


### PR DESCRIPTION
## Fixes #620  by lingxiaoyang

### Changes proposed in this pull request:

* Open a new window if the user wants to print map and directions.
* In the new window, the map, client sequence and directions are reformatted. There is a print button that needs to be clicked to print the new page.

Preview: 
Page 1
![image](https://cloud.githubusercontent.com/assets/8630726/21945346/c5af412a-d9a8-11e6-8019-171044f41bd3.png)

Page 2
![image](https://cloud.githubusercontent.com/assets/8630726/21945352/d2f5299e-d9a8-11e6-8ae1-a795b49155b5.png)


### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

1. Set up kitchen count.
2. Go to the last step, organize a route.
3. Click the print button of "Map and Directions".
4. Repeat 2 and 3, try dragging and zooming the map a few times, and the print content should then change correspondingly.

### Deployment notes and migration
none

### New translatable strings

- [x] If applicable, I have included updated .po files with new strings (see http://goo.gl/kfBO7N)

### Additional notes

Tested with Firefox 50.1.0 and Chrome 55.0.2883.75.

Small caveat 1: in Chrome, the mouse scroll doesn't work in the new window. The user has to drag the scrollbar up and down. A possible solution of setting `body {height:100%;overflow:auto}` will cause Firefox printing only one page.


Note: to correctly print map markers and route direction icons, the browser should be configured to print background color and images.

 - In Firefox, check the two boxes concerning background below in the printing window
![image](https://cloud.githubusercontent.com/assets/8630726/21945126/95497628-d9a7-11e6-910f-896112a92ed9.png)
 - In Chrome, check "Background images" in printing options.
![image](https://cloud.githubusercontent.com/assets/8630726/21945160/bb5526dc-d9a7-11e6-8e0c-35a8e9b42867.png)
