### PR TITLE
Fixed #623: member edit view now accepts GET parameter "next" for redirect

### DIFF
--- a/src/delivery/templates/partials/generated_orders.html
+++ b/src/delivery/templates/partials/generated_orders.html
@@ -38,10 +38,10 @@
           {% if order.client.route %}
             {{order.client.route}}
             {% if not order.client.is_geolocalized %}
-            <a href="{% url 'member:member_update_address_information' pk=order.client.id %}" title="{% trans 'Please fix geolocalization. Otherwise this client will be excluded in the next steps.' %}"><i class="warning sign red icon"></i></a>
+            <a href="{% url 'member:member_update_address_information' pk=order.client.id %}?next={% url 'delivery:order' %}" title="{% trans 'Please fix geolocalization. Otherwise this client will be excluded in the next steps.' %}"><i class="warning sign red icon"></i></a>
             {% endif %}
           {% else %}
-            <a href="{% url 'member:member_update_address_information' pk=order.client.id %}" title="{% trans 'Please fix delivery route. Otherwise this client will be excluded in the next steps.' %}"><i class="warning sign red icon"></i></a>
+            <a href="{% url 'member:member_update_address_information' pk=order.client.id %}?next={% url 'delivery:order' %}" title="{% trans 'Please fix delivery route. Otherwise this client will be excluded in the next steps.' %}"><i class="warning sign red icon"></i></a>
           {% endif %}
         </td>
         <td class="center aligned">{{order.get_status_display}}</td>

--- a/src/member/tests.py
+++ b/src/member/tests.py
@@ -1979,6 +1979,38 @@ class ClientUpdateTestCase(TestCase):
         )
         self.client.login(username=admin.username, password='test1234')
 
+    def test_redirect_to_next(self):
+        """
+        If "?next" exists in URL parameter, the 302 redirect should
+        point to this URL upon successful form submission.
+        """
+        client = ClientFactory()
+        # Load initial data related to the client
+        data = load_initial_data(client)
+        # Update some data
+        data['firstname'] = 'John'
+        data['lastname'] = 'Doe'
+        data['birthdate'] = '1923-03-21'
+        # Login as admin
+        self.login_as_admin()
+
+        # Send the data to the form.
+        response = self.client.post(
+            reverse(
+                'member:member_update_basic_information',
+                kwargs={
+                    'pk': client.id
+                }
+            ) + '?next=/fake/any_url',
+            data,
+            follow=True
+        )
+
+        self.assertRedirects(
+            response, '/fake/any_url',
+            status_code=302, target_status_code=404
+        )
+
 
 class ClientUpdateBasicInformation(ClientUpdateTestCase):
 

--- a/src/member/views.py
+++ b/src/member/views.py
@@ -829,10 +829,14 @@ class ClientUpdateInformation(
         return initial
 
     def get_success_url(self):
-        return reverse_lazy(
-            'member:client_information',
-            kwargs={'pk': self.kwargs.get('pk')}
-        )
+        redirect_url = self.request.GET.get('next')
+        if redirect_url:
+            return redirect_url
+        else:
+            return reverse_lazy(
+                'member:client_information',
+                kwargs={'pk': self.kwargs.get('pk')}
+            )
 
     def form_valid(self, form):
         # This method is called when valid form data has been POSTed.


### PR DESCRIPTION
## Fixes #623 by lingxiaoyang

### Changes proposed in this pull request:

* Add GET parameter `next` on member edit view.
* Add this parameter in the red warning sign in kitchen count order review.
* Add unit test

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

1. Go to http://localhost:8000/delivery/order/, generate today's orders
2. Pick a client, go to django admin, set route=None or set member.address.longitude=None
3. Go back to order review, there should be a warning sign. 
4. Click the warning sign, the opened page should contain a GET parameter 'next'.
5. Fill in the form again, click "Save", the page should be directed back to order review page, with a message on the top "The client has been updated".

![image](https://cloud.githubusercontent.com/assets/8630726/22085599/ae570ac8-dda2-11e6-9acb-7c4c9e0e63b9.png)


### Deployment notes and migration

none

### New translatable strings

none

### Additional notes
none
