### PR TITLE
Fixed #626: Restored Member's quick search inside Client's form.

### DIFF
--- a/src/frontend/js/member.js
+++ b/src/frontend/js/member.js
@@ -131,10 +131,10 @@ $(function() {
         $('.ui.add.form.member').transition('scale');
     }
 
-    $search_url = $('.ui.search').attr('data-url')
+    $search_url = $('.ui.search .ui.input').attr('data-url');
     $('.ui.search').search({
         apiSettings: {
-            cache : 'local',
+            cache : false,
             url: $search_url + '?name={query}',
         },
         minCharacters : 3,

--- a/src/member/templates/client/partials/forms/referent_information.html
+++ b/src/member/templates/client/partials/forms/referent_information.html
@@ -2,8 +2,8 @@
 <h4 class="ui dividing header">{% trans 'Referent' %}</h4>
 
 <div class="ui center aligned basic segment">
-  <div class="ui fluid category search" data-url="{% url 'member:search' %}">
-    <div class="ui icon input">
+  <div class="ui fluid category search">
+    <div class="ui icon input" data-url="{% url 'member:search' %}">
       {{form.member}}
       <i class="search icon"></i>
     </div>


### PR DESCRIPTION
## Fixes #626 by aaboffill

### Changes proposed in this pull request:

* Set to false the cache settings of `semantic` search. 
* Changed the position to provide data-url of Member's quick search. 

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

* Click on Client item menu.
* Select to include a new Client or find an existing Client in order to modify it.
* Go to the Referent tab and try to find different members using several queries in the quick Member search field. The results should match with the search query.
