### PR TITLE
Fixed #638: Added an existing member as client's referent successfully

### DIFF
--- a/src/member/views.py
+++ b/src/member/views.py
@@ -297,7 +297,7 @@ class ClientWizard(
     def save_referent_information(self, client, billing_member, emergency):
         referent_information = self.form_dict['referent_information']
         e_referent = referent_information.cleaned_data.get('member')
-        if self.referent_is_billing_member():
+        if self.referent_is_billing_member() and client.pk != billing_member.pk:
             referent = billing_member
             referent.work_information = referent_information.cleaned_data.get(
                 'work_information'

--- a/src/member/views.py
+++ b/src/member/views.py
@@ -298,8 +298,8 @@ class ClientWizard(
         referent_information = self.form_dict['referent_information']
         e_referent = referent_information.cleaned_data.get('member')
         if (
-            self.referent_is_billing_member()
-            and client.pk != billing_member.pk
+            self.referent_is_billing_member() and
+            client.pk != billing_member.pk
         ):
             referent = billing_member
             referent.work_information = referent_information.cleaned_data.get(

--- a/src/member/views.py
+++ b/src/member/views.py
@@ -297,7 +297,10 @@ class ClientWizard(
     def save_referent_information(self, client, billing_member, emergency):
         referent_information = self.form_dict['referent_information']
         e_referent = referent_information.cleaned_data.get('member')
-        if self.referent_is_billing_member() and client.pk != billing_member.pk:
+        if (
+            self.referent_is_billing_member()
+            and client.pk != billing_member.pk
+        ):
             referent = billing_member
             referent.work_information = referent_information.cleaned_data.get(
                 'work_information'


### PR DESCRIPTION
## Fixes # by aaboffill

### Changes proposed in this pull request:

* Checked if the `billing_member` is the same `Client` before set `billing_member` as `referent`.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

* Create a new client
* At the step Referent, add an existing member
* Save the client
* Check the referent member

