### PR TITLE
Fixed #642: Restored 'ALL' Member's quick search inside Client's form.

### DIFF
--- a/src/member/templates/client/partials/forms/emergency_contact.html
+++ b/src/member/templates/client/partials/forms/emergency_contact.html
@@ -2,8 +2,8 @@
 <h4 class="ui dividing header">{% trans 'Emergency contact' %}</h4>
 
 <div class="ui center aligned basic segment">
-  <div class="ui fluid category search" data-url="{% url 'member:search' %}">
-    <div class="ui icon input">
+  <div class="ui fluid category search">
+    <div class="ui icon input" data-url="{% url 'member:search' %}">
       {{form.member}}
       <i class="search icon"></i>
     </div>

--- a/src/member/templates/client/partials/forms/payment_information.html
+++ b/src/member/templates/client/partials/forms/payment_information.html
@@ -12,8 +12,8 @@
 </div>
 
 <div class="ui center aligned basic segment" id="billing_select_member">
-  <div class="ui fluid category search" data-url="{% url 'member:search' %}">
-    <div class="ui icon input">
+  <div class="ui fluid category search">
+    <div class="ui icon input" data-url="{% url 'member:search' %}">
       {{form.member}}
       <i class="search icon"></i>
     </div>


### PR DESCRIPTION
## Fixes # by aaboffill

### Changes proposed in this pull request:

* Added [fixes](https://github.com/savoirfairelinux/sous-chef/pull/637/files#diff-15f67ab210f6991f3976389f98eddfcd) made for the `Client` `Referent` form, to the`Billing` and `Emergency` forms. 

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

* Click on `Client` item menu.
* Select to include a new `Client`.
* Go to the `Billing` and `Emergency` tabs and try to find different members using several queries in the quick `Member` search field.
