### PR TITLE
Fixed #656: Space allowed for Member quick search

### DIFF
--- a/src/frontend/js/member.js
+++ b/src/frontend/js/member.js
@@ -138,6 +138,7 @@ $(function() {
             url: $search_url + '?name={query}',
         },
         minCharacters : 3,
+        maxResults : 15,
     });
 
     function showOneAccordionElement(element, index, array) {

--- a/src/frontend/js/member.js
+++ b/src/frontend/js/member.js
@@ -138,7 +138,7 @@ $(function() {
             url: $search_url + '?name={query}',
         },
         minCharacters : 3,
-        maxResults : 15,
+        maxResults : 10,
     });
 
     function showOneAccordionElement(element, index, array) {


### PR DESCRIPTION
## Fixes # by aaboffill

### Changes proposed in this pull request:

* Allow space on the `Member` quick search located in the `Client` form.
* Increased result list count to 15

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

* Click on `Client` item menu.
* Select to include a new `Client` or find an existing `Client` in order to modify it.
* Go to the `Referent`, `Payment` or `Emergency` tab and try to find different members writing name and family name.

### Deployment notes and migration

- [ ] Migration is needed for this change

### New translatable strings

- [ ] If applicable, I have included updated .po files with new strings (see http://goo.gl/kfBO7N)

### Additional notes

*If applicable, explain the rationale behind your change.*
