### PR TITLE
Remove the broken edit button that is not used in the billing list page.

### DIFF
--- a/src/billing/templates/billing/list.html
+++ b/src/billing/templates/billing/list.html
@@ -74,7 +74,6 @@
         <td class="center aligned">{{billing.orders__count}}</td>
         <td>
           <a class="ui basic icon button"  href="{% url 'billing:view' pk=billing.id %}"><i class="icon unhide"></i></a>
-          {% if can_edit_data %}<a class="ui basic icon button"  href=""><i class="icon edit"></i></a>{% endif %}
           {% if can_edit_data %}<a class="ui basic icon button billing-delete" href="#" data-billing-id="{{billing.id}}"><i class="icon trash"></i></a>{% endif %}
         </td>
       </tr>


### PR DESCRIPTION
Ref: issue#652

## Fixes # by erozqba

### Changes proposed in this pull request:

* Remove the edit button that is not useful and point to the same page.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

*Fill out this section so that a reviewer can know how to verify your change.*

### Deployment notes and migration

- [ ] Migration is needed for this change

### New translatable strings

- [ ] If applicable, I have included updated .po files with new strings (see http://goo.gl/kfBO7N)

### Additional notes

*If applicable, explain the rationale behind your change.*
