### PR TITLE
Use a different way of calculate the age for the client.

### DIFF
--- a/src/member/models.py
+++ b/src/member/models.py
@@ -378,11 +378,18 @@ class ClientManager(models.Manager):
 
         today = datetime.datetime.now()
 
-        return self.filter(
+        clients = self.filter(
+            birthdate__year__lte=today.year,
             birthdate__month=today.month,
             birthdate__day__gte=today.day,
             birthdate__day__lte=today.day + 7,
         ).order_by(Extract('birthdate', 'day'))
+
+        today = datetime.date.today()
+        for client in clients:
+            client.age_to_celebrate = today.year - client.birthdate.year
+
+        return clients
 
 
 class ActiveClientManager(ClientManager):
@@ -597,34 +604,25 @@ class Client(models.Model):
         """
         Returns integer specifying person's age in years on the current date.
 
+        To compare the Month and Day they need to be in the same year. Since
+        either the birthday can be in a leap year or today can be Feb 29 of a
+        leap year, we need to make sure to compare the days, in a leap year,
+        therefore we are comparing in the year 2000, which was a leap year.
+
         >>> from datetime import date
         >>> p = Client(birthdate=date(1950, 4, 19)
         >>> p.age()
         66
         """
-        from datetime import date
-        current = date.today()
-
-        if current < self.birthdate:
-            return 0
-        return math.floor((current - self.birthdate).days / 365)
-
-    @property
-    def age_to_celebrate_this_year(self):
-        """
-        Returns integer specifying person's age in years on the current year.
-
-        >>> from datetime import date
-        >>> p = Client(birthdate=date(1950, 12, 12)
-        >>> p.age_to_celebrate_this_year()
-        67
-        """
-        from datetime import date
-        current = date.today()
-
-        if current < self.birthdate:
-            return 0
-        return current.year - self.birthdate.year
+        today = datetime.date.today()
+        if today < self.birthdate:
+            age = 0
+        elif datetime.date(2000, self.birthdate.month, self.birthdate.day) <= \
+                datetime.date(2000, today.month, today.day):
+            age = today.year - self.birthdate.year
+        else:
+            age = today.year - self.birthdate.year - 1
+        return age
 
     @property
     def orders(self):

--- a/src/member/templates/client/partials/birthdays.html
+++ b/src/member/templates/client/partials/birthdays.html
@@ -13,7 +13,7 @@
             {% for client in birthday %}
             <tr>
                 <td><a href="{% url 'member:client_information' pk=client.id %}">{{ client }}</a></td>
-                <td>{{ client.age_to_celebrate_this_year }}</td>
+                <td>{{ client.age_to_celebrate }}</td>
                 <td> {{ client.birthdate|date:'MONTH_DAY_FORMAT' }} </td>
             </tr>
             {% endfor %}

--- a/src/member/tests.py
+++ b/src/member/tests.py
@@ -10,7 +10,7 @@ from member.models import CELL, HOME, EMAIL, DAYS_OF_WEEK
 from meal.models import (
     Restricted_item, Ingredient, Component, COMPONENT_GROUP_CHOICES
 )
-from datetime import date
+from datetime import date, timedelta
 from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse, reverse_lazy
 from order.models import Order
@@ -253,8 +253,9 @@ class ClientTestCase(TestCase):
 
     @classmethod
     def setUpTestData(cls):
+        today = date.today()
         cls.ss_client = ClientFactory(
-            birthdate=date(1980, 4, 19),
+            birthdate=date(today.year - 40, today.month, today.day),
             meal_default_week={
                 'monday_size': 'L',
                 'monday_main_dish_quantity': 1
@@ -274,7 +275,18 @@ class ClientTestCase(TestCase):
 
     def test_age(self):
         """The age on given date is properly computed"""
-        self.assertEqual(self.ss_client.age, 36)
+        self.assertEqual(self.ss_client.age, 40)
+        today = date.today()
+        yesterday = today - timedelta(days=1)
+        tomorrow = today + timedelta(days=1)
+        self.ss_client.birthdate = date(yesterday.year - 40, yesterday.month,
+                                        yesterday.day)
+        self.ss_client.save()
+        self.assertEqual(Client.objects.get(id=self.ss_client.id).age, 40)
+        self.ss_client.birthdate = date(tomorrow.year - 40, tomorrow.month,
+                                        tomorrow.day)
+        self.ss_client.save()
+        self.assertEqual(Client.objects.get(id=self.ss_client.id).age, 39)
 
     def test_orders(self):
         """Orders of a given client must be available as a model property"""


### PR DESCRIPTION
Ref: issue#669

## Fixes # by erozqba

### Changes proposed in this pull request:

* Use a different way to calculate client age based in date.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Check if the clients ages are correctly calculated one day after and before his birthday. 