### PR TITLE
Revised grouping of meal labels

### DIFF
--- a/src/delivery/fixtures/sample_data.json
+++ b/src/delivery/fixtures/sample_data.json
@@ -1729,7 +1729,7 @@
         "model": "member.client",
         "fields": {
             "emergency_contact_relationship": "Friend",
-            "route": 1,
+            "route": 3,
             "billing_payment_type": "check",
             "gender": "M",
             "delivery_note": "",
@@ -1974,7 +1974,7 @@
         "pk": 509,
         "model": "member.client_option",
         "fields": {
-            "value": "cut-up meat",
+            "value": "X",
             "client": 608,
             "option": 889
         }
@@ -2040,6 +2040,15 @@
             "value": "[\"monday\", \"tuesday\", \"wednesday\", \"thursday\", \"friday\", \"saturday\", \"sunday\"]",
             "client": 612,
             "option": 1
+        }
+    },
+    {
+        "pk": 517,
+        "model": "member.client_option",
+        "fields": {
+            "value": "X",
+            "client": 611,
+            "option": 889
         }
     },
     {
@@ -15951,15 +15960,6 @@
         }
     },
     {
-        "model": "member.client_option",
-        "pk": 101,
-        "fields": {
-            "client": 101,
-            "option": 195,
-            "value": "X"
-        }
-    },
-    {
         "model": "member.restriction",
         "pk": 101,
         "fields": {
@@ -16124,14 +16124,6 @@
         }
     },
     {
-        "model": "member.client_avoid_ingredient",
-        "pk": 103,
-        "fields": {
-            "client": 103,
-            "ingredient": 3388
-        }
-    },
-    {
         "model": "member.member",
         "pk": 104,
         "fields": {
@@ -16182,15 +16174,6 @@
             "client": 104,
             "referral_reason": "Needs help.",
             "date": "2016-12-21"
-        }
-    },
-    {
-        "model": "member.client_option",
-        "pk": 104,
-        "fields": {
-            "client": 104,
-            "option": 195,
-            "value": "X"
         }
     },
     {
@@ -16325,7 +16308,7 @@
             "delivery_type": "O",
             "gender": "M",
             "birthdate": "1941-11-12",
-            "route": 196,
+            "route": 3,
             "meal_default_week": "{\n  \"compote_friday_quantity\": 1,\n  \"compote_monday_quantity\": 1,\n  \"compote_saturday_quantity\": 1,\n  \"compote_sunday_quantity\": 1,\n  \"compote_thursday_quantity\": 1,\n  \"compote_tuesday_quantity\": 1,\n  \"compote_wednesday_quantity\": 1,\n  \"dessert_friday_quantity\": 0,\n  \"dessert_monday_quantity\": 0,\n  \"dessert_saturday_quantity\": 0,\n  \"dessert_sunday_quantity\": 0,\n  \"dessert_thursday_quantity\": 0,\n  \"dessert_tuesday_quantity\": 0,\n  \"dessert_wednesday_quantity\": 0,\n  \"diabetic_dessert_friday_quantity\": 0,\n  \"diabetic_dessert_monday_quantity\": 0,\n  \"diabetic_dessert_saturday_quantity\": 0,\n  \"diabetic_dessert_sunday_quantity\": 0,\n  \"diabetic_dessert_thursday_quantity\": 0,\n  \"diabetic_dessert_tuesday_quantity\": 0,\n  \"diabetic_dessert_wednesday_quantity\": 0,\n  \"fruit_salad_friday_quantity\": 0,\n  \"fruit_salad_monday_quantity\": 0,\n  \"fruit_salad_saturday_quantity\": 0,\n  \"fruit_salad_sunday_quantity\": 0,\n  \"fruit_salad_thursday_quantity\": 0,\n  \"fruit_salad_tuesday_quantity\": 0,\n  \"fruit_salad_wednesday_quantity\": 0,\n  \"green_salad_friday_quantity\": 0,\n  \"green_salad_monday_quantity\": 0,\n  \"green_salad_saturday_quantity\": 0,\n  \"green_salad_sunday_quantity\": 0,\n  \"green_salad_thursday_quantity\": 0,\n  \"green_salad_tuesday_quantity\": 0,\n  \"green_salad_wednesday_quantity\": 0,\n  \"main_dish_friday_quantity\": 1,\n  \"main_dish_monday_quantity\": 1,\n  \"main_dish_saturday_quantity\": 1,\n  \"main_dish_sunday_quantity\": 1,\n  \"main_dish_thursday_quantity\": 1,\n  \"main_dish_tuesday_quantity\": 1,\n  \"main_dish_wednesday_quantity\": 1,\n  \"pudding_friday_quantity\": 0,\n  \"pudding_monday_quantity\": 0,\n  \"pudding_saturday_quantity\": 0,\n  \"pudding_sunday_quantity\": 0,\n  \"pudding_thursday_quantity\": 0,\n  \"pudding_tuesday_quantity\": 0,\n  \"pudding_wednesday_quantity\": 0,\n  \"size_friday\": \"R\",\n  \"size_monday\": \"R\",\n  \"size_saturday\": \"R\",\n  \"size_sunday\": \"R\",\n  \"size_thursday\": \"R\",\n  \"size_tuesday\": \"R\",\n  \"size_wednesday\": \"R\"\n}",
             "delivery_note": "Ring door bell many times."
         }
@@ -16436,14 +16419,6 @@
         }
     },
     {
-        "model": "member.client_avoid_ingredient",
-        "pk": 107,
-        "fields": {
-            "client": 107,
-            "ingredient": 3388
-        }
-    },
-    {
         "model": "member.member",
         "pk": 108,
         "fields": {
@@ -16494,15 +16469,6 @@
             "client": 108,
             "referral_reason": "Needs help.",
             "date": "2016-12-21"
-        }
-    },
-    {
-        "model": "member.client_option",
-        "pk": 108,
-        "fields": {
-            "client": 108,
-            "option": 195,
-            "value": "X"
         }
     },
     {
@@ -16592,14 +16558,6 @@
         }
     },
     {
-        "model": "member.client_avoid_ingredient",
-        "pk": 109,
-        "fields": {
-            "client": 109,
-            "ingredient": 3388
-        }
-    },
-    {
         "model": "member.member",
         "pk": 110,
         "fields": {
@@ -16650,15 +16608,6 @@
             "client": 110,
             "referral_reason": "Needs help.",
             "date": "2016-12-21"
-        }
-    },
-    {
-        "model": "member.client_option",
-        "pk": 110,
-        "fields": {
-            "client": 110,
-            "option": 195,
-            "value": "X"
         }
     },
     {

--- a/src/delivery/views.py
+++ b/src/delivery/views.py
@@ -1030,13 +1030,23 @@ def kcr_make_labels(kitchen_list, main_dish_name, main_dish_ingredients):
     for label in meal_labels:
         routew = max(routew, len(label.route))
         namew = max(namew, len(label.name))
-    # generate sorting key
-    meal_labels = [
-        label._replace(
-            sortkey='{rou:{rouw}}{nam:{namw}}'.format(
-                rou=label.route, rouw=routew,
-                nam=label.name, namw=namew))
-        for label in meal_labels]
+    # generate grouping and sorting key
+    for j in range(len(meal_labels)):
+        route = ''  # for groups 1, 2 and 3 : sort by name
+        if meal_labels[j].dish_clashes:     # has dish restrictions
+            group = 1
+        elif meal_labels[j].sides_clashes:  # has sides restrictions
+            group = 2
+        elif meal_labels[j].preparations:   # has food preparations
+            group = 3
+        else:                               # regular meal
+            group = 4
+            route = meal_labels[j].route        # sort by route, name
+        meal_labels[j] = meal_labels[j]._replace(
+            sortkey='{grp:1}{rou:{rouw}}{nam:{namw}}'.format(
+                grp=group,
+                rou=route, rouw=routew,
+                nam=meal_labels[j].name, namw=namew))
     # generate labels into PDF
     for label in sorted(meal_labels, key=lambda x: x.sortkey):
         sheet.add_label(label)


### PR DESCRIPTION
## Fixes #667.

### Changes proposed in this pull request:

* delivery/views.py : modified meal labels sorting logic.
* delivery/fixtures/sample_data.json : adjusted client routes, restrictions and preferences to obtain more variety in label data.
* delivery/tests.py : modified test for labels.

### Status

- [X] READY

### How to verify this change
1- Stop webserver
2- Backup your current database
3- Start webserver
4- python manage.py flush
5- python manage.py createsuperuser
6- python manage.py loaddata sample_data
7- login to SousChef
8- In SousChef menu, click Kitchen Count
9- click Generate orders
10- click I'm ready
11- choose Ginger pork as main dish
12- choose Brussel sprouts, Potatoes as sides ingredients
13- click print Kitchen Count
14- click download labels to open PDF labels sheet
15- Notice that labels are grouped are in this order : Main dish restrictions (sorted by name), Sides clashes  (sorted by name), Preparation (sorted by name), Regular meals  (sorted by route then by name).
