### PR TITLE
Fixed #636: Removed django warning for 2.0

### DIFF
--- a/src/billing/urls.py
+++ b/src/billing/urls.py
@@ -5,6 +5,8 @@ from billing.views import (
 )
 from django.utils.translation import ugettext_lazy as _
 
+app_name = "billing"
+
 urlpatterns = [
     url(r'^list/$', BillingList.as_view(), name="list"),
     url(r'^create/$', BillingCreate.as_view(), name="create"),

--- a/src/delivery/urls.py
+++ b/src/delivery/urls.py
@@ -7,6 +7,8 @@ from delivery.views import (Orderlist, MealInformation, RoutesInformation,
                             SaveRouteVehicleView, OrganizeRoute,
                             RouteInformation)
 
+app_name = "delivery"
+
 urlpatterns = [
     url(_(r'^order/$'), Orderlist.as_view(), name='order'),
     url(_(r'^meal/$'), MealInformation.as_view(), name='meal'),

--- a/src/meal/models.py
+++ b/src/meal/models.py
@@ -114,12 +114,16 @@ class Component_ingredient(models.Model):
     component = models.ForeignKey(
         'meal.Component',
         verbose_name=_('component'),
-        related_name='+')
+        related_name='+',
+        on_delete=models.CASCADE
+    )
 
     ingredient = models.ForeignKey(
         'meal.Ingredient',
         verbose_name=_('ingredient'),
-        related_name='+')
+        related_name='+',
+        on_delete=models.CASCADE
+    )
 
     date = models.DateField(
         verbose_name=_('date'),
@@ -177,12 +181,16 @@ class Incompatibility(models.Model):
     restricted_item = models.ForeignKey(
         'meal.Restricted_item',
         verbose_name=_('restricted item'),
-        related_name='+')
+        related_name='+',
+        on_delete=models.CASCADE
+    )
 
     ingredient = models.ForeignKey(
         'meal.Ingredient',
         verbose_name=_('ingredient'),
-        related_name='+')
+        related_name='+',
+        on_delete=models.CASCADE
+    )
 
     def __str__(self):
         return "{} <clash> {}".format(self.restricted_item.name,
@@ -266,12 +274,16 @@ class Menu_component(models.Model):
     menu = models.ForeignKey(
         'meal.Menu',
         verbose_name=_('menu'),
-        related_name='+')
+        related_name='+',
+        on_delete=models.CASCADE
+    )
 
     component = models.ForeignKey(
         'meal.Component',
         verbose_name=_('component'),
-        related_name='+')
+        related_name='+',
+        on_delete=models.CASCADE
+    )
 
     def __str__(self):
         return "On {} <menu includes> {}".format(str(self.menu.date),

--- a/src/meal/urls.py
+++ b/src/meal/urls.py
@@ -1,4 +1,4 @@
 from django.conf.urls import url
 
-urlpatterns = [
-]
+app_name = "meal"
+urlpatterns = []

--- a/src/member/models.py
+++ b/src/member/models.py
@@ -117,6 +117,7 @@ class Member(models.Model):
         'member.Address',
         verbose_name=_('address'),
         null=True,
+        on_delete=models.CASCADE
     )
 
     work_information = models.TextField(
@@ -309,6 +310,7 @@ class Contact(models.Model):
         'member.Member',
         verbose_name=_('member'),
         related_name='member_contact',
+        on_delete=models.CASCADE
     )
 
     def display_value(self):
@@ -466,6 +468,7 @@ class Client(models.Model):
         'member.Member',
         related_name='+',
         verbose_name=_('billing member'),
+        on_delete=models.CASCADE
     )
 
     billing_payment_type = models.CharField(
@@ -485,7 +488,8 @@ class Client(models.Model):
 
     member = models.ForeignKey(
         'member.Member',
-        verbose_name=_('member')
+        verbose_name=_('member'),
+        on_delete=models.CASCADE
     )
 
     emergency_contact = models.ForeignKey(
@@ -493,6 +497,7 @@ class Client(models.Model):
         verbose_name=_('emergency contact'),
         related_name='emergency_contact',
         null=True,
+        on_delete=models.CASCADE
     )
 
     emergency_contact_relationship = models.CharField(
@@ -1028,12 +1033,18 @@ class Referencing (models.Model):
     class Meta:
         verbose_name_plural = _('referents')
 
-    referent = models.ForeignKey('member.Member',
-                                 verbose_name=_('referent'))
+    referent = models.ForeignKey(
+        'member.Member',
+        verbose_name=_('referent'),
+        on_delete=models.CASCADE
+    )
 
-    client = models.ForeignKey('member.Client',
-                               verbose_name=_('client'),
-                               related_name='client_referent')
+    client = models.ForeignKey(
+        'member.Client',
+        verbose_name=_('client'),
+        related_name='client_referent',
+        on_delete=models.CASCADE
+    )
 
     referral_reason = models.TextField(
         verbose_name=_("Referral reason")
@@ -1083,12 +1094,16 @@ class Client_option(models.Model):
     client = models.ForeignKey(
         'member.Client',
         verbose_name=_('client'),
-        related_name='+')
+        related_name='+',
+        on_delete=models.CASCADE
+    )
 
     option = models.ForeignKey(
         'member.option',
         verbose_name=_('option'),
-        related_name='+')
+        related_name='+',
+        on_delete=models.CASCADE
+    )
 
     value = models.CharField(
         max_length=255,
@@ -1111,12 +1126,16 @@ class Restriction(models.Model):
     client = models.ForeignKey(
         'member.Client',
         verbose_name=_('client'),
-        related_name='+')
+        related_name='+',
+        on_delete=models.CASCADE
+    )
 
     restricted_item = models.ForeignKey(
         'meal.Restricted_item',
         verbose_name=_('restricted item'),
-        related_name='+')
+        related_name='+',
+        on_delete=models.CASCADE
+    )
 
     def __str__(self):
         return "{} {} <restricts> {}".format(self.client.member.firstname,
@@ -1128,12 +1147,16 @@ class Client_avoid_ingredient(models.Model):
     client = models.ForeignKey(
         'member.Client',
         verbose_name=_('client'),
-        related_name='+')
+        related_name='+',
+        on_delete=models.CASCADE
+    )
 
     ingredient = models.ForeignKey(
         'meal.Ingredient',
         verbose_name=_('ingredient'),
-        related_name='+')
+        related_name='+',
+        on_delete=models.CASCADE
+    )
 
     def __str__(self):
         return "{} {} <has> {}".format(self.client.member.firstname,
@@ -1145,12 +1168,16 @@ class Client_avoid_component(models.Model):
     client = models.ForeignKey(
         'member.Client',
         verbose_name=_('client'),
-        related_name='+')
+        related_name='+',
+        on_delete=models.CASCADE
+    )
 
     component = models.ForeignKey(
         'meal.Component',
         verbose_name=_('component'),
-        related_name='+')
+        related_name='+',
+        on_delete=models.CASCADE
+    )
 
     def __str__(self):
         return "{} {} <has> {}".format(self.client.member.firstname,

--- a/src/member/urls.py
+++ b/src/member/urls.py
@@ -35,6 +35,8 @@ from member.forms import (
 
 from note.views import ClientNoteList, ClientNoteListAdd
 
+app_name = "member"
+
 create_member_forms = (
     ('basic_information', ClientBasicInformation),
     ('address_information', ClientAddressInformation),

--- a/src/member/views.py
+++ b/src/member/views.py
@@ -7,7 +7,7 @@ from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.contrib.auth.decorators import login_required
-from django.core.urlresolvers import reverse_lazy, reverse
+from django.urls import reverse_lazy, reverse
 from django.db.models import Q
 from django.http import HttpResponseRedirect, JsonResponse, HttpResponse
 from django.shortcuts import get_object_or_404

--- a/src/note/models.py
+++ b/src/note/models.py
@@ -59,6 +59,7 @@ class Note(models.Model):
         User,
         verbose_name=_('Author'),
         null=True,
+        on_delete=models.CASCADE
     )
 
     date = models.DateTimeField(
@@ -74,21 +75,24 @@ class Note(models.Model):
     client = models.ForeignKey(
         'member.Client',
         verbose_name=_('Client'),
-        related_name='client_notes'
+        related_name='client_notes',
+        on_delete=models.CASCADE
     )
 
     priority = models.ForeignKey(
         NotePriority,
         verbose_name=_('Priority'),
         related_name="notes",
-        default=NotePriority.DEFAULT_PRIORITY_ID
+        default=NotePriority.DEFAULT_PRIORITY_ID,
+        on_delete=models.CASCADE
     )
 
     category = models.ForeignKey(
         NoteCategory,
         verbose_name=_('Category'),
         related_name="notes",
-        default=NoteCategory.DEFAULT_CATEGORY_ID
+        default=NoteCategory.DEFAULT_CATEGORY_ID,
+        on_delete=models.CASCADE
     )
 
     objects = NoteManager()

--- a/src/note/urls.py
+++ b/src/note/urls.py
@@ -5,6 +5,8 @@ from note.views import NoteList, NoteAdd, NoteBatchToggle
 
 from note.views import mark_as_read, mark_as_unread
 
+app_name = "note"
+
 urlpatterns = [
     url(_(r'^$'), NoteList.as_view(), name='note_list'),
     url(_(r'^read/(?P<id>\d+)/$'),

--- a/src/notification/models.py
+++ b/src/notification/models.py
@@ -14,7 +14,8 @@ class Notification(models.Model):
 
     member = models.ForeignKey(
         'member.Member',
-        verbose_name=_('member')
+        verbose_name=_('member'),
+        on_delete=models.CASCADE
     )
 
     date = models.DateField(

--- a/src/notification/urls.py
+++ b/src/notification/urls.py
@@ -1,4 +1,4 @@
 from django.conf.urls import url
 
-urlpatterns = [
-]
+app_name = "notification"
+urlpatterns = []

--- a/src/order/models.py
+++ b/src/order/models.py
@@ -5,9 +5,8 @@ import re
 from django.db import models, connection, transaction
 from django.db.models import Q
 from django.utils.translation import ugettext_lazy as _
-from django.utils import timezone
 from django_filters import FilterSet, ChoiceFilter, CharFilter
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.core.exceptions import ValidationError
 
 from member.models import (Client, Member, Route,
@@ -340,7 +339,8 @@ class Order(models.Model):
         verbose_name=_('client'),
         related_name='client_order',
         blank=False,
-        default=""
+        default="",
+        on_delete=models.CASCADE
     )
 
     objects = OrderManager()
@@ -1085,6 +1085,7 @@ class Order_item(models.Model):
         'order.Order',
         verbose_name=_('order'),
         related_name='orders',
+        on_delete=models.CASCADE
     )
 
     price = models.DecimalField(

--- a/src/order/urls.py
+++ b/src/order/urls.py
@@ -11,6 +11,8 @@ from order.views import (
     CreateDeleteOrderClientBill,
     DeleteOrder)
 
+app_name = "order"
+
 urlpatterns = [
     url(_(r'^list/$'), OrderList.as_view(), name='list'),
     url(_(r'^view/(?P<pk>\d+)/$'), OrderDetail.as_view(), name='view'),

--- a/src/page/urls.py
+++ b/src/page/urls.py
@@ -2,6 +2,8 @@ from django.conf.urls import url
 from page import views
 from django.contrib.auth import views as auth_views
 
+app_name = "page"
+
 urlpatterns = [
     url(
         r'^home$',

--- a/src/page/views.py
+++ b/src/page/views.py
@@ -4,7 +4,7 @@ from django.contrib.auth.views import login
 from django.http import HttpResponseRedirect
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.auth.mixins import PermissionRequiredMixin
-from django.core.urlresolvers import reverse_lazy
+from django.urls import reverse_lazy
 from django.db.models import Count, Case, When, IntegerField
 from django.views.generic import TemplateView
 from member.models import Client, Route

--- a/src/sous_chef/settings.py
+++ b/src/sous_chef/settings.py
@@ -12,7 +12,7 @@ https://docs.djangoproject.com/en/1.9/ref/settings/
 """
 
 import os
-from django.core.urlresolvers import reverse_lazy
+from django.urls import reverse_lazy
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -69,7 +69,7 @@ INSTALLED_APPS = [
     'note',
 ]
 
-MIDDLEWARE_CLASSES = [
+MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',


### PR DESCRIPTION
## Fixes # by aaboffill

### Changes proposed in this pull request:

Removed all `RemovedInDjango20Warning` from sous-chef's code. 
* Replaced [`django.core.urlresolvers` by `django.urls`](https://docs.djangoproject.com/en/1.10/ref/urlresolvers/#module-django.urls).
* Added [`app_name` to `urls.py`](https://github.com/django/django/blob/master/django/conf/urls/__init__.py#L17-L48)
* Added  [`on_delete` argument to the `ForeignKey`](https://docs.djangoproject.com/en/1.10/ref/models/fields/#django.db.models.ForeignKey.on_delete)
* Replaced [`MIDDLEWARE_CLASSES` by `MIDDLEWARE`](https://docs.djangoproject.com/en/1.10/topics/http/middleware/#middleware)

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

* During your own development, use env variable PYTHONWARNINGS=once to show them.

### Additional notes

We have still the following warnings:
* `RemovedInDjango20Warning`: '**site-packages/avatar/models.py:75**'. This is an external library, the latest version keep the warning, we need to wait.
* `RemovedInDjango20Warning`: '**site-packages/formtools/wizard/views.py:5**'. This is an external library, the latest version keep the warning, we need to wait.
* `RemovedInDjango20Warning`: **site-packages/rules/templatetags/rules.py:10**'. This is an external library, the latest version keep the warning, we need to wait.
* `DeprecationWarning`: '**site-packages/rules/predicates.py:70**'. This warning is not related with `Django`.
* `RemovedInLocalflavor20Warning`: '**site-packages/localflavor/generic/forms.py:144**'. This warning is not related with `Django`.
* `PendingDeprecationWarning`: '**dist-packages/reportlab/__init__.py:8**'. This warning is not related with `Django`.
