### PR TITLE
Fixed #617: Translated JS strings

### DIFF
--- a/src/frontend/js/custom-leaflet.js
+++ b/src/frontend/js/custom-leaflet.js
@@ -360,6 +360,7 @@ $(function() {
 
         // Display a loading indicator
         $('form').addClass('loading');
+        var notFoundMsg = $(this).data('notFoundMsg');
 
         var geocoder = new L.Control.Geocoder.nominatim({ geocodingQueryParams: { countrycodes: 'ca'}});
         // var yourQuery = "4846 rue cartier, Montreal, Qc";
@@ -409,7 +410,7 @@ $(function() {
                   });
             }
             else {
-                alert("Address not Found !!");
+                alert(notFoundMsg);
             }
 
             // Remove the loading indicator

--- a/src/frontend/js/page.js
+++ b/src/frontend/js/page.js
@@ -3,6 +3,11 @@ $(function() {
     // Javascript of the page application.
     // **************************************
 
+    var form = $('.ui.large.form'),
+        usernameEmptyMsg = form.data('usernameEmptyMsg'),
+        passwordEmptyMsg = form.data('passwordEmptyMsg'),
+        passwordMinLengthMsg = form.data('passwordMinLengthMsg');
+
     $('.ui.large.form').form({
         on: 'submit',
         revalidate: 'false',
@@ -11,17 +16,17 @@ $(function() {
                 identifier: 'username',
                 rules: [{
                     type   : 'empty',
-                    prompt : 'Please enter a username'
+                    prompt : usernameEmptyMsg
                 }]
             },
             password: {
                 identifier: 'password',
                 rules: [{
                     type   : 'empty',
-                    prompt : 'Please enter a password'
+                    prompt : passwordEmptyMsg
                     },{
                     type   : 'minLength[6]',
-                    prompt : 'Your password must be at least {ruleValue} characters'
+                    prompt : passwordMinLengthMsg
                 }]
             }
         }

--- a/src/member/locale/en/LC_MESSAGES/django.po
+++ b/src/member/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-01-11 15:12+0000\n"
+"POT-Creation-Date: 2017-03-01 13:58-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,566 +17,559 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: member/forms.py:24 member/forms.py:261 member/forms.py:263
-#: member/templates/client/view/information.html:34
-#: member/templates/client/view/information.html:66
-#: member/templates/client/view/payment.html:32
-#: member/templates/client/view/referent.html:32
+#: forms.py:24 forms.py:261 forms.py:263
+#: templates/client/view/information.html:34
+#: templates/client/view/information.html:72
+#: templates/client/view/payment.html:32 templates/client/view/referent.html:32
 msgid "First Name"
 msgstr ""
 
-#: member/forms.py:25
+#: forms.py:25
 msgid "First name"
 msgstr ""
 
-#: member/forms.py:30 member/forms.py:270 member/forms.py:272
-#: member/templates/client/view/information.html:35
-#: member/templates/client/view/information.html:67
-#: member/templates/client/view/payment.html:35
-#: member/templates/client/view/referent.html:33
+#: forms.py:30 forms.py:270 forms.py:272
+#: templates/client/view/information.html:35
+#: templates/client/view/information.html:73
+#: templates/client/view/payment.html:35 templates/client/view/referent.html:33
 msgid "Last Name"
 msgstr ""
 
-#: member/forms.py:31
+#: forms.py:31
 msgid "Last name"
 msgstr ""
 
-#: member/forms.py:41
+#: forms.py:41
 msgid "Preferred language"
 msgstr ""
 
-#: member/forms.py:46 member/templates/client/view/information.html:39
+#: forms.py:46 templates/client/view/information.html:39
 msgid "Birthday"
 msgstr ""
 
-#: member/forms.py:50 member/forms.py:346 member/forms.py:481
+#: forms.py:50 forms.py:347 forms.py:497
 msgid "YYYY-MM-DD"
 msgstr ""
 
-#: member/forms.py:53 member/forms.py:349 member/forms.py:484
+#: forms.py:53 forms.py:350 forms.py:500
 msgid "Format: YYYY-MM-DD"
 msgstr ""
 
-#: member/forms.py:59 member/forms.py:280
+#: forms.py:59 forms.py:280
 msgid "Email"
 msgstr ""
 
-#: member/forms.py:65
+#: forms.py:65
 msgid "Home phone"
 msgstr ""
 
-#: member/forms.py:71 member/forms.py:292
+#: forms.py:71 forms.py:292
 msgid "Cellular"
 msgstr ""
 
-#: member/forms.py:76
-#: member/templates/client/partials/forms/basic_information.html:67
+#: forms.py:76 templates/client/partials/forms/basic_information.html:67
 msgid "Alert"
 msgstr ""
 
-#: member/forms.py:80
+#: forms.py:80
 msgid "Your message here ..."
 msgstr ""
 
-#: member/forms.py:88
+#: forms.py:88
 msgid "At least one contact information is required."
 msgstr ""
 
-#: member/forms.py:99 member/forms.py:101 member/forms.py:379
-#: member/forms.py:380
+#: forms.py:99 forms.py:101 forms.py:395 forms.py:396
 msgid "Apt #"
 msgstr ""
 
-#: member/forms.py:109
+#: forms.py:109
 msgid "Address Information"
 msgstr ""
 
-#: member/forms.py:111
+#: forms.py:111
 msgid "7275 Rue Saint-Urbain"
 msgstr ""
 
-#: member/forms.py:118
+#: forms.py:118
 msgid "City"
 msgstr ""
 
-#: member/forms.py:120
+#: forms.py:120
 msgid "Montreal"
 msgstr ""
 
-#: member/forms.py:127 member/forms.py:390
+#: forms.py:127 forms.py:406
 msgid "Postal Code"
 msgstr ""
 
-#: member/forms.py:129
+#: forms.py:129
 msgid "H2R 2Y5"
 msgstr ""
 
-#: member/forms.py:135
+#: forms.py:135
 msgid "Latitude"
 msgstr ""
 
-#: member/forms.py:142
+#: forms.py:142
 msgid "Longitude"
 msgstr ""
 
-#: member/forms.py:149
+#: forms.py:149
 msgid "Distance from Santropol"
 msgstr ""
 
-#: member/forms.py:156 member/templates/client/list.html:102
-#: member/templates/client/partials/filters.html:16
+#: forms.py:156 templates/client/list.html:102
+#: templates/client/partials/filters.html:16
+#: templates/client/view/information.html:49
 msgid "Route"
 msgstr ""
 
-#: member/forms.py:163 member/models.py:542
-#: member/templates/client/view/information.html:44
+#: forms.py:163 models.py:558 templates/client/view/information.html:50
 msgid "Delivery Note"
 msgstr ""
 
-#: member/forms.py:167
+#: forms.py:167
 msgid "Delivery Note here ..."
 msgstr ""
 
-#: member/forms.py:177 member/models.py:41
-#: member/templates/client/partials/forms/meal_prefs.html:6
+#: forms.py:177 models.py:43 templates/client/partials/forms/meal_prefs.html:6
 msgid "Default"
 msgstr ""
 
-#: member/forms.py:196 member/models.py:432
+#: forms.py:196 models.py:448
 msgid "Active"
 msgstr ""
 
-#: member/forms.py:197
+#: forms.py:197
 msgid "By default, the client meal status is Pending."
 msgstr ""
 
-#: member/forms.py:202
+#: forms.py:202
 msgid "Type"
 msgstr ""
 
-#: member/forms.py:209
+#: forms.py:209
 msgid "Schedule"
 msgstr ""
 
-#: member/forms.py:217 member/templates/client/view/allergies.html:36
+#: forms.py:217 templates/client/view/allergies.html:36
 msgid "Restrictions"
 msgstr ""
 
-#: member/forms.py:224 member/models.py:64
+#: forms.py:224 models.py:66
 msgid "Preparation"
 msgstr ""
 
-#: member/forms.py:231
+#: forms.py:231
 msgid "Ingredient To Avoid"
 msgstr ""
 
-#: member/forms.py:240
+#: forms.py:240
 msgid "Dish(es) To Avoid"
 msgstr ""
 
-#: member/forms.py:252 member/forms.py:254
+#: forms.py:252 forms.py:254
 msgid "Member"
 msgstr ""
 
-#: member/forms.py:286
+#: forms.py:286
 msgid "Work phone"
 msgstr ""
 
-#: member/forms.py:308
+#: forms.py:308
 msgid "This field is required unless you add a new member."
 msgstr ""
 
-#: member/forms.py:311 member/forms.py:439 member/forms.py:445
+#: forms.py:311 forms.py:363 forms.py:455 forms.py:461
 msgid "This field is required unless you chose an existing member."
 msgstr ""
 
-#: member/forms.py:321 member/forms.py:434
+#: forms.py:321 forms.py:450
 msgid "Not a valid member, please chose an existing member."
 msgstr ""
 
-#: member/forms.py:330 member/models.py:1020
+#: forms.py:330 models.py:123
 msgid "Work information"
 msgstr ""
 
-#: member/forms.py:332
+#: forms.py:332
 msgid "Hotel-Dieu, St-Anne Hospital, ..."
 msgstr ""
 
-#: member/forms.py:337 member/templates/client/view/referent.html:36
+#: forms.py:338 templates/client/view/referent.html:36
 msgid "Referral Reason"
 msgstr ""
 
-#: member/forms.py:342 member/templates/client/view/referent.html:35
+#: forms.py:343 templates/client/view/referent.html:35
 msgid "Referral Date"
 msgstr ""
 
-#: member/forms.py:356
+#: forms.py:372
 msgid "Billing Type"
 msgstr ""
 
-#: member/forms.py:362
+#: forms.py:378
 msgid "Same As Client"
 msgstr ""
 
-#: member/forms.py:364
+#: forms.py:380
 msgid ""
 "If checked, the personal information             of the client will be used "
 "as billing information."
 msgstr ""
 
-#: member/forms.py:370 member/models.py:456
+#: forms.py:386 models.py:472
 msgid "Payment Type"
 msgstr ""
 
-#: member/forms.py:376
+#: forms.py:392
 msgid "Street Number"
 msgstr ""
 
-#: member/forms.py:384
+#: forms.py:400
 msgid "Floor"
 msgstr ""
 
-#: member/forms.py:386
+#: forms.py:402
 msgid "Street Name"
 msgstr ""
 
-#: member/forms.py:388
+#: forms.py:404
 msgid "City Name"
 msgstr ""
 
-#: member/forms.py:403
+#: forms.py:419
 msgid ""
 "This member has not a valid address, please add a valid address to this "
 "member, so it can be used for the billing."
 msgstr ""
 
-#: member/forms.py:408
+#: forms.py:424
 msgid "This field is required"
 msgstr ""
 
-#: member/forms.py:420 member/templates/client/view/information.html:68
+#: forms.py:436 templates/client/view/information.html:74
 msgid "Relationship"
 msgstr ""
 
-#: member/forms.py:422
+#: forms.py:438
 msgid "Parent, friend, ..."
 msgstr ""
 
-#: member/forms.py:452
+#: forms.py:468
 msgid "At least one emergency contact is required."
 msgstr ""
 
-#: member/models.py:28
+#: models.py:30
 msgid "Female"
 msgstr ""
 
-#: member/models.py:29
+#: models.py:31
 msgid "Male"
 msgstr ""
 
-#: member/models.py:30
+#: models.py:32
 msgid "Other"
 msgstr ""
 
-#: member/models.py:42
+#: models.py:44
 msgid "Low income"
 msgstr ""
 
-#: member/models.py:43
+#: models.py:45
 msgid "Solidary"
 msgstr ""
 
-#: member/models.py:50
+#: models.py:52
 msgid "----"
 msgstr ""
 
-#: member/models.py:51
+#: models.py:53
 msgid "3rd Party"
 msgstr ""
 
-#: member/models.py:52
+#: models.py:54
 msgid "Credit card"
 msgstr ""
 
-#: member/models.py:53
+#: models.py:55
 msgid "EFT"
 msgstr ""
 
-#: member/models.py:57
+#: models.py:59
 msgid "Ongoing"
 msgstr ""
 
-#: member/models.py:58
+#: models.py:60
 msgid "Episodic"
 msgstr ""
 
-#: member/models.py:62
+#: models.py:64
 msgid "Main dish size"
 msgstr ""
 
-#: member/models.py:63
+#: models.py:65
 msgid "Dish"
 msgstr ""
 
-#: member/models.py:65
+#: models.py:67
 msgid "Other order item"
 msgstr ""
 
-#: member/models.py:71
+#: models.py:73
 msgid "Monday"
 msgstr ""
 
-#: member/models.py:72
+#: models.py:74
 msgid "Tuesday"
 msgstr ""
 
-#: member/models.py:73
+#: models.py:75
 msgid "Wednesday"
 msgstr ""
 
-#: member/models.py:74
+#: models.py:76
 msgid "Thursday"
 msgstr ""
 
-#: member/models.py:75
+#: models.py:77
 msgid "Friday"
 msgstr ""
 
-#: member/models.py:76
+#: models.py:78
 msgid "Saturday"
 msgstr ""
 
-#: member/models.py:77
+#: models.py:79
 msgid "Sunday"
 msgstr ""
 
-#: member/models.py:82
+#: models.py:84
 msgid "Cycling"
 msgstr ""
 
-#: member/models.py:83
+#: models.py:85
 msgid "Walking"
 msgstr ""
 
-#: member/models.py:84
+#: models.py:86
 msgid "Driving"
 msgstr ""
 
-#: member/models.py:93
+#: models.py:95
 msgid "members"
 msgstr ""
 
-#: member/models.py:106
+#: models.py:108
 msgid "firstname"
 msgstr ""
 
-#: member/models.py:111
+#: models.py:113
 msgid "lastname"
 msgstr ""
 
-#: member/models.py:116
+#: models.py:118
 msgid "address"
 msgstr ""
 
-#: member/models.py:219
+#: models.py:227
 msgid "addresses"
 msgstr ""
 
-#: member/models.py:223
+#: models.py:231
 msgid "street number"
 msgstr ""
 
-#: member/models.py:230
+#: models.py:238
 msgid "street"
 msgstr ""
 
-#: member/models.py:236
+#: models.py:244
 msgid "apartment"
 msgstr ""
 
-#: member/models.py:242
+#: models.py:250
 msgid "floor"
 msgstr ""
 
-#: member/models.py:249
+#: models.py:257
 msgid "city"
 msgstr ""
 
-#: member/models.py:255
+#: models.py:263
 msgid "postal code"
 msgstr ""
 
-#: member/models.py:286
+#: models.py:294
 msgid "contacts"
 msgstr ""
 
-#: member/models.py:292
+#: models.py:300
 msgid "contact type"
 msgstr ""
 
-#: member/models.py:297 member/models.py:1079
+#: models.py:305 models.py:1096
 msgid "value"
 msgstr ""
 
-#: member/models.py:302 member/models.py:472
+#: models.py:310 models.py:488
 msgid "member"
 msgstr ""
 
-#: member/models.py:324
+#: models.py:332
 msgid "Routes"
 msgstr ""
 
-#: member/models.py:330 member/models.py:1046
+#: models.py:338 models.py:1063
 msgid "name"
 msgstr ""
 
-#: member/models.py:334 member/models.py:1050
+#: models.py:342 models.py:1067
 msgid "description"
 msgstr ""
 
-#: member/models.py:342
-msgid "default vehicle"
+#: models.py:350
+msgid "vehicle"
 msgstr ""
 
-#: member/models.py:431
+#: models.py:447
 msgid "Pending"
 msgstr ""
 
-#: member/models.py:433
+#: models.py:449
 msgid "Paused"
 msgstr ""
 
-#: member/models.py:434
+#: models.py:450
 msgid "Stop: no contact"
 msgstr ""
 
-#: member/models.py:435
+#: models.py:451
 msgid "Stop: contact"
 msgstr ""
 
-#: member/models.py:436
+#: models.py:452
 msgid "Deceased"
 msgstr ""
 
-#: member/models.py:440
+#: models.py:456
 msgid "English"
 msgstr ""
 
-#: member/models.py:441
+#: models.py:457
 msgid "French"
 msgstr ""
 
-#: member/models.py:442
+#: models.py:458
 msgid "Allophone"
 msgstr ""
 
-#: member/models.py:446
+#: models.py:462
 msgid "clients"
 msgstr ""
 
-#: member/models.py:452
+#: models.py:468
 msgid "billing member"
 msgstr ""
 
-#: member/models.py:464
+#: models.py:480
 msgid "rate type"
 msgstr ""
 
-#: member/models.py:477
+#: models.py:493
 msgid "emergency contact"
 msgstr ""
 
-#: member/models.py:484
+#: models.py:500
 msgid "emergency contact relationship"
 msgstr ""
 
-#: member/models.py:502
+#: models.py:518
 msgid "alert client"
 msgstr ""
 
-#: member/models.py:532
+#: models.py:548
 msgid "route"
 msgstr ""
 
-#: member/models.py:843
+#: models.py:867
 msgid "Start"
 msgstr ""
 
-#: member/models.py:844
+#: models.py:868
 msgid "End"
 msgstr ""
 
-#: member/models.py:852
+#: models.py:876
 msgid "To be processed"
 msgstr ""
 
-#: member/models.py:853
+#: models.py:877
 msgid "Processed"
 msgstr ""
 
-#: member/models.py:854
+#: models.py:878
 msgid "Error"
 msgstr ""
 
-#: member/models.py:952
+#: models.py:976
 msgid "All"
 msgstr ""
 
-#: member/models.py:965
+#: models.py:989
 msgid "Search by name"
 msgstr ""
 
-#: member/models.py:1006
+#: models.py:1029
 msgid "referents"
 msgstr ""
 
-#: member/models.py:1009
+#: models.py:1032
 msgid "referent"
 msgstr ""
 
-#: member/models.py:1012 member/models.py:1068 member/models.py:1096
-#: member/models.py:1113 member/models.py:1130
+#: models.py:1035 models.py:1085 models.py:1113 models.py:1130 models.py:1147
 msgid "client"
 msgstr ""
 
-#: member/models.py:1016
-#: member/templates/client/partials/forms/referent_information.html:69
+#: models.py:1039 templates/client/partials/forms/referent_information.html:70
 msgid "Referral reason"
 msgstr ""
 
-#: member/models.py:1026
+#: models.py:1043
 msgid "Referral date"
 msgstr ""
 
-#: member/models.py:1041
+#: models.py:1058
 msgid "options"
 msgstr ""
 
-#: member/models.py:1058
+#: models.py:1075
 msgid "option group"
 msgstr ""
 
-#: member/models.py:1073
+#: models.py:1090
 msgid "option"
 msgstr ""
 
-#: member/models.py:1101
+#: models.py:1118
 msgid "restricted item"
 msgstr ""
 
-#: member/models.py:1118
+#: models.py:1135
 msgid "ingredient"
 msgstr ""
 
-#: member/models.py:1135
+#: models.py:1152
 msgid "component"
 msgstr ""
 
-#: member/templates/client/base.html:7
+#: templates/client/base.html:7 templates/client/partials/birthdays.html:8
 msgid "Client"
 msgstr ""
 
-#: member/templates/client/base.html:18
+#: templates/client/base.html:18
 #, python-format
 msgid ""
 "\n"
@@ -584,154 +577,138 @@ msgid ""
 "                "
 msgstr ""
 
-#: member/templates/client/base.html:51
+#: templates/client/base.html:51
 msgid "Important notice"
 msgstr ""
 
-#: member/templates/client/create/form.html:18
+#: templates/client/create/form.html:18
 msgid "Edit existing client"
 msgstr ""
 
-#: member/templates/client/create/form.html:18
+#: templates/client/create/form.html:18
 msgid "Create a new client "
 msgstr ""
 
-#: member/templates/client/create/form.html:24
+#: templates/client/create/form.html:24
 msgid "Notice"
 msgstr ""
 
-#: member/templates/client/create/form.html:26
+#: templates/client/create/form.html:26
 msgid "No information will be saved until all the steps are completed."
 msgstr ""
 
-#: member/templates/client/create/form.html:28
+#: templates/client/create/form.html:28
 msgid "Save as soon as you are ready."
 msgstr ""
 
-#: member/templates/client/create/form.html:38
+#: templates/client/create/form.html:38
 msgid "Edit Client"
 msgstr ""
 
-#: member/templates/client/create/form.html:38
+#: templates/client/create/form.html:38
 msgid "New Client"
 msgstr ""
 
-#: member/templates/client/create/form.html:44
-#: member/templates/client/partials/menu.html:10
-#: member/templates/client/update/base.html:36
+#: templates/client/create/form.html:44 templates/client/partials/menu.html:10
+#: templates/client/update/base.html:36
 msgid "Personal"
 msgstr ""
 
-#: member/templates/client/create/form.html:44
-#: member/templates/client/update/base.html:36
+#: templates/client/create/form.html:44 templates/client/update/base.html:36
 msgid "First name, last name, ..."
 msgstr ""
 
-#: member/templates/client/create/form.html:45
-#: member/templates/client/partials/forms/address_information.html:2
-#: member/templates/client/update/base.html:37
-#: member/templates/client/view/information.html:43
-#: member/templates/client/view/payment.html:45
-#: member/templates/client/view/summary.html:14
+#: templates/client/create/form.html:45
+#: templates/client/partials/forms/address_information.html:2
+#: templates/client/update/base.html:37
+#: templates/client/view/information.html:44
+#: templates/client/view/payment.html:44 templates/client/view/summary.html:14
 msgid "Address"
 msgstr ""
 
-#: member/templates/client/create/form.html:45
-#: member/templates/client/update/base.html:37
+#: templates/client/create/form.html:45 templates/client/update/base.html:37
 msgid "Street number, city, ..."
 msgstr ""
 
-#: member/templates/client/create/form.html:46
-#: member/templates/client/partials/forms/referent_information.html:2
-#: member/templates/client/partials/menu.html:12
-#: member/templates/client/update/base.html:38
-#: member/templates/client/view/referent.html:19
+#: templates/client/create/form.html:46
+#: templates/client/partials/forms/referent_information.html:2
+#: templates/client/partials/menu.html:12 templates/client/update/base.html:38
+#: templates/client/view/referent.html:19
 msgid "Referent"
 msgstr ""
 
-#: member/templates/client/create/form.html:46
-#: member/templates/client/update/base.html:38
+#: templates/client/create/form.html:46 templates/client/update/base.html:38
 msgid "Referent contact information"
 msgstr ""
 
-#: member/templates/client/create/form.html:47
-#: member/templates/client/update/base.html:39
+#: templates/client/create/form.html:47 templates/client/update/base.html:39
 msgid "Payment"
 msgstr ""
 
-#: member/templates/client/create/form.html:47
-#: member/templates/client/update/base.html:39
+#: templates/client/create/form.html:47 templates/client/update/base.html:39
 msgid "Payment method, card, ..."
 msgstr ""
 
-#: member/templates/client/create/form.html:48
-#: member/templates/client/partials/menu.html:19
-#: member/templates/client/update/base.html:40
+#: templates/client/create/form.html:48 templates/client/partials/menu.html:19
+#: templates/client/update/base.html:40
 msgid "Preferences"
 msgstr ""
 
-#: member/templates/client/create/form.html:48
-#: member/templates/client/update/base.html:40
+#: templates/client/create/form.html:48 templates/client/update/base.html:40
 msgid "Deliveries, restrictions, ..."
 msgstr ""
 
-#: member/templates/client/create/form.html:49
-#: member/templates/client/update/base.html:41
+#: templates/client/create/form.html:49 templates/client/update/base.html:41
 msgid "Emergency"
 msgstr ""
 
-#: member/templates/client/create/form.html:49
-#: member/templates/client/update/base.html:41
+#: templates/client/create/form.html:49 templates/client/update/base.html:41
 msgid "Emergency contact information"
 msgstr ""
 
-#: member/templates/client/create/form.html:57
-#: member/templates/client/update/base.html:50
+#: templates/client/create/form.html:57 templates/client/update/base.html:50
 msgid "Required information missing"
 msgstr ""
 
-#: member/templates/client/create/form.html:58
-#: member/templates/client/update/base.html:51
+#: templates/client/create/form.html:58 templates/client/update/base.html:51
 msgid ""
 "Please review the form to make sure that all required fields are filled."
 msgstr ""
 
-#: member/templates/client/create/form.html:69
-#: member/templates/client/update/base.html:59
+#: templates/client/create/form.html:69 templates/client/update/base.html:59
 msgid "Back"
 msgstr ""
 
-#: member/templates/client/create/form.html:74
-#: member/templates/client/update/base.html:60
+#: templates/client/create/form.html:74 templates/client/update/base.html:60
 msgid "Save"
 msgstr ""
 
-#: member/templates/client/create/form.html:76
+#: templates/client/create/form.html:76
 msgid "Next"
 msgstr ""
 
-#: member/templates/client/list.html:6 member/templates/client/list.html:11
-#: member/templates/client/list.html:18
+#: templates/client/list.html:6 templates/client/list.html:11
+#: templates/client/list.html:18
 msgid "Clients"
 msgstr ""
 
-#: member/templates/client/list.html:34
+#: templates/client/list.html:34
 msgid "New client"
 msgstr ""
 
-#: member/templates/client/list.html:37
-#: member/templates/client/partials/forms/emergency_contact.html:13
-#: member/templates/client/partials/forms/payment_information.html:23
-#: member/templates/client/partials/forms/referent_information.html:13
+#: templates/client/list.html:37
+#: templates/client/partials/forms/emergency_contact.html:13
+#: templates/client/partials/forms/payment_information.html:23
+#: templates/client/partials/forms/referent_information.html:13
 msgid "Or"
 msgstr ""
 
-#: member/templates/client/list.html:56 member/templates/client/list.html:113
-#: member/templates/client/view/summary.html:36
+#: templates/client/list.html:56 templates/client/list.html:113
+#: templates/client/view/summary.html:36
 msgid "years old"
 msgstr ""
 
-#: member/templates/client/list.html:60
+#: templates/client/list.html:60
 #, python-format
 msgid ""
 "\n"
@@ -740,541 +717,546 @@ msgid ""
 "                "
 msgstr ""
 
-#: member/templates/client/list.html:64
+#: templates/client/list.html:64
 msgid "This client is currently"
 msgstr ""
 
-#: member/templates/client/list.html:84 member/templates/client/list.html:131
+#: templates/client/list.html:84 templates/client/list.html:131
 msgid "Sorry, no result found."
 msgstr ""
 
-#: member/templates/client/list.html:93
-#: member/templates/client/partials/filters.html:7
-#: member/templates/client/partials/forms/basic_information.html:4
-#: member/templates/client/partials/forms/emergency_contact.html:27
-#: member/templates/client/partials/forms/payment_information.html:37
-#: member/templates/client/partials/forms/referent_information.html:26
+#: templates/client/list.html:93 templates/client/partials/filters.html:7
+#: templates/client/partials/forms/basic_information.html:4
+#: templates/client/partials/forms/emergency_contact.html:27
+#: templates/client/partials/forms/payment_information.html:37
+#: templates/client/partials/forms/referent_information.html:26
 msgid "Name"
 msgstr ""
 
-#: member/templates/client/list.html:94
+#: templates/client/list.html:94
 msgid "Full name and age of the client."
 msgstr ""
 
-#: member/templates/client/list.html:96
-#: member/templates/client/partials/filters.html:22
-#: member/templates/client/partials/menu.html:15
-#: member/templates/client/view/orders.html:35
+#: templates/client/list.html:96 templates/client/partials/filters.html:30
+#: templates/client/partials/menu.html:15 templates/client/view/orders.html:35
 msgid "Status"
 msgstr ""
 
-#: member/templates/client/list.html:97
+#: templates/client/list.html:97
 msgid ""
 "Meal status. Available status are: Pending, Active, Paused, Stop: no "
 "contact, Stop: contact and Deceased."
 msgstr ""
 
-#: member/templates/client/list.html:99
-#: member/templates/client/view/summary.html:7
+#: templates/client/list.html:99 templates/client/view/summary.html:7
 msgid "Delivery type"
 msgstr ""
 
-#: member/templates/client/list.html:100
+#: templates/client/list.html:100
 msgid "A client can be either an ongoing or an episodic client."
 msgstr ""
 
-#: member/templates/client/list.html:103
+#: templates/client/list.html:103
 msgid "The delivery route for the client."
 msgstr ""
 
-#: member/templates/client/list.html:105
+#: templates/client/list.html:105
 msgid "Last update"
 msgstr ""
 
-#: member/templates/client/list.html:106
+#: templates/client/list.html:106
 msgid "Last modification of the file."
 msgstr ""
 
-#: member/templates/client/list.html:145
+#: templates/client/list.html:145
 msgid "of"
 msgstr ""
 
-#: member/templates/client/partials/birthdays.html:3
+#: templates/client/partials/birthdays.html:3
 msgid "Happy Birthday"
 msgstr ""
 
-#: member/templates/client/partials/filters.html:28
-#: member/templates/client/partials/forms/dietary_restriction.html:13
+#: templates/client/partials/birthdays.html:9
+msgid "Age"
+msgstr ""
+
+#: templates/client/partials/birthdays.html:10
+#: templates/client/view/status.html:42
+msgid "Date"
+msgstr ""
+
+#: templates/client/partials/birthdays.html:25
+#, python-format
+msgid "%(count)s birthday."
+msgid_plural "%(count)s birthdays."
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/client/partials/filters.html:22
+#: templates/client/partials/forms/dietary_restriction.html:13
 msgid "Delivery"
 msgstr ""
 
-#: member/templates/client/partials/filters.html:36
-#: member/templates/client/view/notes.html:49
-#: member/templates/client/view/status.html:33
+#: templates/client/partials/filters.html:36
+#: templates/client/view/notes.html:49 templates/client/view/status.html:33
 msgid "Reset"
 msgstr ""
 
-#: member/templates/client/partials/filters.html:37
-#: member/templates/client/view/notes.html:50
+#: templates/client/partials/filters.html:37
+#: templates/client/view/notes.html:50
 msgid "Search"
 msgstr ""
 
-#: member/templates/client/partials/forms/address_information.html:27
+#: templates/client/partials/forms/address_information.html:27
 msgid "Geolocation"
 msgstr ""
 
-#: member/templates/client/partials/forms/address_information.html:31
+#: templates/client/partials/forms/address_information.html:30
+msgid "Address not Found !!"
+msgstr ""
+
+#: templates/client/partials/forms/address_information.html:31
 msgid "Geolocate"
 msgstr ""
 
-#: member/templates/client/partials/forms/address_information.html:33
+#: templates/client/partials/forms/address_information.html:33
 msgid "Geolocation is mandatory."
 msgstr ""
 
-#: member/templates/client/partials/forms/address_information.html:49
+#: templates/client/partials/forms/address_information.html:49
 msgid "km"
 msgstr ""
 
-#: member/templates/client/partials/forms/address_information.html:59
+#: templates/client/partials/forms/address_information.html:59
 msgid "Delivery Route"
 msgstr ""
 
-#: member/templates/client/partials/forms/basic_information.html:2
+#: templates/client/partials/forms/basic_information.html:2
 msgid "Identity"
 msgstr ""
 
-#: member/templates/client/partials/forms/basic_information.html:34
-#: member/templates/client/partials/forms/basic_information.html:43
-#: member/templates/client/partials/forms/emergency_contact.html:37
+#: templates/client/partials/forms/basic_information.html:34
+#: templates/client/partials/forms/basic_information.html:43
+#: templates/client/partials/forms/emergency_contact.html:37
 msgid "Contact information"
 msgstr ""
 
-#: member/templates/client/partials/forms/basic_information.html:70
+#: templates/client/partials/forms/basic_information.html:70
 msgid "This message will be hightlighted on the client record."
 msgstr ""
 
-#: member/templates/client/partials/forms/dietary_restriction.html:2
-#: member/templates/client/view/allergies.html:31
+#: templates/client/partials/forms/dietary_restriction.html:2
+#: templates/client/view/allergies.html:31
 msgid "Meal status"
 msgstr ""
 
-#: member/templates/client/partials/forms/dietary_restriction.html:33
-#: member/templates/client/view/allergies.html:10
+#: templates/client/partials/forms/dietary_restriction.html:33
+#: templates/client/view/allergies.html:10
 msgid "Food preferences"
 msgstr ""
 
-#: member/templates/client/partials/forms/emergency_contact.html:2
+#: templates/client/partials/forms/emergency_contact.html:2
 msgid "Emergency contact"
 msgstr ""
 
-#: member/templates/client/partials/forms/emergency_contact.html:16
+#: templates/client/partials/forms/emergency_contact.html:16
 msgid "Create new emergency contact"
 msgstr ""
 
-#: member/templates/client/partials/forms/emergency_contact.html:65
+#: templates/client/partials/forms/emergency_contact.html:65
 msgid "Contact relationship"
 msgstr ""
 
-#: member/templates/client/partials/forms/meal_defaults.html:16
-#: member/templates/client/partials/forms/meal_prefs.html:12
-#: member/templates/client/partials/meal_defaults.html:13
+#: templates/client/partials/forms/meal_defaults.html:16
+#: templates/client/partials/forms/meal_prefs.html:12
+#: templates/client/partials/meal_defaults.html:13
 msgid "Size"
 msgstr ""
 
-#: member/templates/client/partials/forms/meal_defaults.html:17
-#: member/templates/client/partials/forms/meal_prefs.html:13
-#: member/templates/client/partials/meal_defaults.html:14
+#: templates/client/partials/forms/meal_defaults.html:17
+#: templates/client/partials/forms/meal_prefs.html:13
+#: templates/client/partials/meal_defaults.html:14
 msgid "Component"
 msgstr ""
 
-#: member/templates/client/partials/forms/meal_defaults.html:18
-#: member/templates/client/partials/forms/meal_prefs.html:14
-#: member/templates/client/partials/meal_defaults.html:15
+#: templates/client/partials/forms/meal_defaults.html:18
+#: templates/client/partials/forms/meal_prefs.html:14
+#: templates/client/partials/meal_defaults.html:15
 msgid "Quantity"
 msgstr ""
 
-#: member/templates/client/partials/forms/payment_information.html:2
+#: templates/client/partials/forms/payment_information.html:2
 msgid "Billing information"
 msgstr ""
 
-#: member/templates/client/partials/forms/payment_information.html:26
+#: templates/client/partials/forms/payment_information.html:26
 msgid "Create new payment member"
 msgstr ""
 
-#: member/templates/client/partials/forms/payment_information.html:49
+#: templates/client/partials/forms/payment_information.html:49
 msgid "Street"
 msgstr ""
 
-#: member/templates/client/partials/forms/referent_information.html:16
+#: templates/client/partials/forms/referent_information.html:16
 msgid "Create new referent member"
 msgstr ""
 
-#: member/templates/client/partials/forms/referent_information.html:83
+#: templates/client/partials/forms/referent_information.html:84
 msgid "Please describe the referral reason(s)"
 msgstr ""
 
-#: member/templates/client/partials/menu.html:8
-#: member/templates/client/view/information.html:9
-#: member/templates/client/view/notes.html:9
-#: member/templates/client/view/status.html:8
+#: templates/client/partials/menu.html:8
+#: templates/client/view/information.html:9 templates/client/view/notes.html:9
+#: templates/client/view/status.html:8
 msgid "Information"
 msgstr ""
 
-#: member/templates/client/partials/menu.html:13
+#: templates/client/partials/menu.html:13
 msgid "Add a referent"
 msgstr ""
 
-#: member/templates/client/partials/menu.html:13
+#: templates/client/partials/menu.html:13
 msgid "No referent available"
 msgstr ""
 
-#: member/templates/client/partials/menu.html:14
-#: member/templates/client/view/payment.html:19
+#: templates/client/partials/menu.html:14 templates/client/view/payment.html:19
 msgid "Billing"
 msgstr ""
 
-#: member/templates/client/partials/menu.html:23
+#: templates/client/partials/menu.html:23
 msgid "Notes"
 msgstr ""
 
-#: member/templates/client/partials/menu.html:27
-#: member/templates/client/view/orders.html:20
+#: templates/client/partials/menu.html:27 templates/client/view/orders.html:20
 msgid "Orders"
 msgstr ""
 
-#: member/templates/client/partials/prefs.html:15
+#: templates/client/partials/prefs.html:15
 msgid "No delivery."
 msgstr ""
 
-#: member/templates/client/update/base.html:14
-#: member/templates/client/update/base.html:30
+#: templates/client/update/base.html:14 templates/client/update/base.html:30
 msgid "Update Client"
 msgstr ""
 
-#: member/templates/client/update/base.html:20
+#: templates/client/update/base.html:20
 msgid "Tip"
 msgstr ""
 
-#: member/templates/client/update/base.html:21
+#: templates/client/update/base.html:21
 msgid "In update mode, each step can be saved individually"
 msgstr ""
 
-#: member/templates/client/update/status.html:3
+#: templates/client/update/status.html:3
 msgid "Status modification"
 msgstr ""
 
-#: member/templates/client/update/status.html:20
+#: templates/client/update/status.html:20
 msgid ""
 "If you want to schedule a status modification, feel free to fill one or two "
 "of theses date fields."
 msgstr ""
 
-#: member/templates/client/update/status.html:33
+#: templates/client/update/status.html:33
 msgid "End date"
 msgstr ""
 
-#: member/templates/client/update/status.html:45
+#: templates/client/update/status.html:45
 msgid "Cancel"
 msgstr ""
 
-#: member/templates/client/update/status.html:46
+#: templates/client/update/status.html:46
 msgid "OK"
 msgstr ""
 
-#: member/templates/client/view/allergies.html:19
+#: templates/client/view/allergies.html:19
 msgid "Meal information"
 msgstr ""
 
-#: member/templates/client/view/allergies.html:20
+#: templates/client/view/allergies.html:20
 msgid "Meal information of the referent person"
 msgstr ""
 
-#: member/templates/client/view/allergies.html:24
-#: member/templates/client/view/allergies.html:101
-#: member/templates/client/view/information.html:27
-#: member/templates/client/view/information.html:59
-#: member/templates/client/view/payment.html:26
-#: member/templates/client/view/referent.html:25
+#: templates/client/view/allergies.html:24
+#: templates/client/view/allergies.html:101
+#: templates/client/view/information.html:27
+#: templates/client/view/information.html:65
+#: templates/client/view/payment.html:26 templates/client/view/referent.html:25
 msgid "Edit"
 msgstr ""
 
-#: member/templates/client/view/allergies.html:45
+#: templates/client/view/allergies.html:45
 msgid "Yipee! No restriction"
 msgstr ""
 
-#: member/templates/client/view/allergies.html:50
+#: templates/client/view/allergies.html:50
 msgid "Food preparation"
 msgstr ""
 
-#: member/templates/client/view/allergies.html:59
+#: templates/client/view/allergies.html:59
 msgid "Nope! Nothing specific"
 msgstr ""
 
-#: member/templates/client/view/allergies.html:64
+#: templates/client/view/allergies.html:64
 msgid "Ingredients to avoid"
 msgstr ""
 
-#: member/templates/client/view/allergies.html:73
-#: member/templates/client/view/allergies.html:87
+#: templates/client/view/allergies.html:73
+#: templates/client/view/allergies.html:87
 msgid "Yeah! Likes everything"
 msgstr ""
 
-#: member/templates/client/view/allergies.html:78
+#: templates/client/view/allergies.html:78
 msgid "Dish(es) to avoid"
 msgstr ""
 
-#: member/templates/client/view/allergies.html:96
+#: templates/client/view/allergies.html:96
 msgid "Meal schedule"
 msgstr ""
 
-#: member/templates/client/view/allergies.html:97
+#: templates/client/view/allergies.html:97
 msgid "Meal default schedule of the referent person"
 msgstr ""
 
-#: member/templates/client/view/information.html:19
+#: templates/client/view/information.html:19
 msgid "Basic information"
 msgstr ""
 
-#: member/templates/client/view/information.html:21
+#: templates/client/view/information.html:21
 msgid "Contact information of the client"
 msgstr ""
 
-#: member/templates/client/view/information.html:36
+#: templates/client/view/information.html:36
 msgid "Gender"
 msgstr ""
 
-#: member/templates/client/view/information.html:37
-#: member/templates/client/view/summary.html:28
+#: templates/client/view/information.html:37
+#: templates/client/view/summary.html:28
 msgid "Language"
 msgstr ""
 
-#: member/templates/client/view/information.html:38
+#: templates/client/view/information.html:38
 msgid "Delivery Type"
 msgstr ""
 
-#: member/templates/client/view/information.html:53
+#: templates/client/view/information.html:59
 msgid "Emergency Contact"
 msgstr ""
 
-#: member/templates/client/view/information.html:54
+#: templates/client/view/information.html:60
 msgid "Information of the person to contact in case of an emergency"
 msgstr ""
 
-#: member/templates/client/view/notes.html:19
+#: templates/client/view/notes.html:19
 msgid "Staff Notes"
 msgstr ""
 
-#: member/templates/client/view/notes.html:21
+#: templates/client/view/notes.html:21
 msgid "Notes added to"
 msgstr ""
 
-#: member/templates/client/view/notes.html:21
+#: templates/client/view/notes.html:21
 msgid "s file"
 msgstr ""
 
-#: member/templates/client/view/notes.html:33
+#: templates/client/view/notes.html:33
 msgid "Priority"
 msgstr ""
 
-#: member/templates/client/view/notes.html:40
+#: templates/client/view/notes.html:40
 msgid "Is read"
 msgstr ""
 
-#: member/templates/client/view/notes.html:53
+#: templates/client/view/notes.html:53
 msgid "New Note"
 msgstr ""
 
-#: member/templates/client/view/notes.html:75
+#: templates/client/view/notes.html:75
 msgid "Done/Read"
 msgstr ""
 
-#: member/templates/client/view/notes.html:78
+#: templates/client/view/notes.html:78
 msgid "New"
 msgstr ""
 
-#: member/templates/client/view/orders.html:9
+#: templates/client/view/orders.html:9
 msgid "Orders list"
 msgstr ""
 
-#: member/templates/client/view/orders.html:21
+#: templates/client/view/orders.html:21
 msgid "List of all orders from"
 msgstr ""
 
-#: member/templates/client/view/orders.html:29
+#: templates/client/view/orders.html:29
 msgid "Order"
 msgstr ""
 
-#: member/templates/client/view/orders.html:30
+#: templates/client/view/orders.html:30
 msgid "A unique identifier for the order."
 msgstr ""
 
-#: member/templates/client/view/orders.html:32
+#: templates/client/view/orders.html:32
 msgid "Delivery Date"
 msgstr ""
 
-#: member/templates/client/view/orders.html:33
+#: templates/client/view/orders.html:33
 msgid "The delivery date planned for the order."
 msgstr ""
 
-#: member/templates/client/view/orders.html:36
+#: templates/client/view/orders.html:36
 msgid "The order status"
 msgstr ""
 
-#: member/templates/client/view/orders.html:38
+#: templates/client/view/orders.html:38
 msgid "Amount"
 msgstr ""
 
-#: member/templates/client/view/orders.html:39
+#: templates/client/view/orders.html:39
 msgid "Total amount in $CAD."
 msgstr ""
 
-#: member/templates/client/view/orders.html:41
+#: templates/client/view/orders.html:41
 msgid "Actions"
 msgstr ""
 
-#: member/templates/client/view/payment.html:9
-#: member/templates/client/view/referent.html:9
+#: templates/client/view/payment.html:9 templates/client/view/referent.html:9
 msgid "Referent information"
 msgstr ""
 
-#: member/templates/client/view/payment.html:20
+#: templates/client/view/payment.html:20
 msgid "Billing and payment information"
 msgstr ""
 
-#: member/templates/client/view/payment.html:38
+#: templates/client/view/payment.html:38
 msgid "Payment method"
 msgstr ""
 
-#: member/templates/client/view/payment.html:41
+#: templates/client/view/payment.html:41
 msgid "Rate type"
 msgstr ""
 
-#: member/templates/client/view/referent.html:20
+#: templates/client/view/referent.html:20
 msgid "Contact information of the referent person"
 msgstr ""
 
-#: member/templates/client/view/referent.html:34
+#: templates/client/view/referent.html:34
 msgid "Workplace information"
 msgstr ""
 
-#: member/templates/client/view/status.html:17
+#: templates/client/view/status.html:17
 msgid "Scheduled status modifications"
 msgstr ""
 
-#: member/templates/client/view/status.html:19
+#: templates/client/view/status.html:19
 msgid "Here are listed all scheduled status modifications."
 msgstr ""
 
-#: member/templates/client/view/status.html:34
+#: templates/client/view/status.html:34
 msgid "Apply"
 msgstr ""
 
-#: member/templates/client/view/status.html:42
-msgid "Date"
-msgstr ""
-
-#: member/templates/client/view/status.html:43
+#: templates/client/view/status.html:43
 msgid "From"
 msgstr ""
 
-#: member/templates/client/view/status.html:44
+#: templates/client/view/status.html:44
 msgid "To"
 msgstr ""
 
-#: member/templates/client/view/status.html:45
+#: templates/client/view/status.html:45
 msgid "Reason"
 msgstr ""
 
-#: member/templates/client/view/status.html:46
+#: templates/client/view/status.html:46
 msgid "Operation status"
 msgstr ""
 
-#: member/templates/client/view/status.html:52
+#: templates/client/view/status.html:52
 msgid "No status modification."
 msgstr ""
 
-#: member/templates/client/view/summary.html:21
+#: templates/client/view/summary.html:21
 msgid "Home"
 msgstr ""
 
-#: member/templatetags/member_extras.py:34
+#: templatetags/member_extras.py:34
 #, python-format
 msgid "%(count)s %(size)s %(component_label)s"
 msgstr ""
 
-#: member/templatetags/member_extras.py:39
+#: templatetags/member_extras.py:39
 #, python-format
 msgid "%(count)s %(component_label)s"
 msgstr ""
 
-#: member/urls.py:57
+#: urls.py:57
 msgid "^view/(?P<pk>\\d+)/$"
 msgstr ""
 
-#: member/urls.py:58
+#: urls.py:58
 msgid "^view/(?P<pk>\\d+)/orders$"
 msgstr ""
 
-#: member/urls.py:60
+#: urls.py:60
 msgid "^view/(?P<pk>\\d+)/information$"
 msgstr ""
 
-#: member/urls.py:62
+#: urls.py:62
 msgid "^view/(?P<pk>\\d+)/referent$"
 msgstr ""
 
-#: member/urls.py:64
+#: urls.py:64
 msgid "^view/(?P<pk>\\d+)/billing$"
 msgstr ""
 
-#: member/urls.py:66
+#: urls.py:66
 msgid "^view/(?P<pk>\\d+)/preferences$"
 msgstr ""
 
-#: member/urls.py:68
+#: urls.py:68
 msgid "^view/(?P<pk>\\d+)/notes$"
 msgstr ""
 
-#: member/urls.py:70
+#: urls.py:70
 msgid "^view/(?P<pk>\\d+)/notes/add$"
 msgstr ""
 
-#: member/urls.py:72
+#: urls.py:72
 msgid "^geolocateAddress/$"
 msgstr ""
 
-#: member/urls.py:73
+#: urls.py:73
 msgid "^view/(?P<pk>\\d+)/status$"
 msgstr ""
 
-#: member/urls.py:77
+#: urls.py:77
 msgid "^restriction/(?P<pk>\\d+)/delete/$"
 msgstr ""
 
-#: member/urls.py:79
+#: urls.py:79
 msgid "^client_option/(?P<pk>\\d+)/delete/$"
 msgstr ""
 
-#: member/urls.py:81
+#: urls.py:81
 msgid "^ingredient_to_avoid/(?P<pk>\\d+)/delete/$"
 msgstr ""
 
-#: member/urls.py:83
+#: urls.py:83
 msgid "^component_to_avoid/(?P<pk>\\d+)/delete/$"
 msgstr ""
 
-#: member/urls.py:104
+#: urls.py:104
 msgid "^(?P<pk>\\d+)/update/{}/$"
 msgstr ""
 
-#: member/views.py:95
+#: views.py:95
 msgid "The client has been created"
 msgstr ""
 
-#: member/views.py:835
+#: views.py:832
 msgid "The client has been updated"
 msgstr ""
 
-#: member/views.py:1381
+#: views.py:1402
 msgid "The status has been changed"
 msgstr ""

--- a/src/member/locale/fr/LC_MESSAGES/django.po
+++ b/src/member/locale/fr/LC_MESSAGES/django.po
@@ -2,213 +2,221 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-11-22 23:01+0000\n"
+"POT-Creation-Date: 2017-03-01 13:58-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: PascalPriori <pascal.priori@savoirfairelinux.com>, 2016\n"
-"Language-Team: French (https://www.transifex.com/savoirfairelinux/teams/63058/fr/)\n"
+"Language-Team: French (https://www.transifex.com/savoirfairelinux/"
+"teams/63058/fr/)\n"
+"Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: fr\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: member/forms.py:18 member/forms.py:235 member/forms.py:237
-#: member/templates/client/view/information.html:30
-#: member/templates/client/view/information.html:60
-#: member/templates/client/view/payment.html:28
-#: member/templates/client/view/referent.html:27
+#: forms.py:24 forms.py:261 forms.py:263
+#: templates/client/view/information.html:34
+#: templates/client/view/information.html:72
+#: templates/client/view/payment.html:32 templates/client/view/referent.html:32
 msgid "First Name"
 msgstr "Prénom"
 
-#: member/forms.py:19
+#: forms.py:25
 msgid "First name"
 msgstr "Prénom"
 
-#: member/forms.py:24 member/forms.py:244 member/forms.py:246
-#: member/templates/client/view/information.html:31
-#: member/templates/client/view/information.html:61
-#: member/templates/client/view/payment.html:31
-#: member/templates/client/view/referent.html:28
+#: forms.py:30 forms.py:270 forms.py:272
+#: templates/client/view/information.html:35
+#: templates/client/view/information.html:73
+#: templates/client/view/payment.html:35 templates/client/view/referent.html:33
 msgid "Last Name"
 msgstr "Nom de famille"
 
-#: member/forms.py:25
+#: forms.py:31
 msgid "Last name"
 msgstr "Nom de famille"
 
-#: member/forms.py:35
+#: forms.py:41
 msgid "Preferred language"
 msgstr "Langue d'usage"
 
-#: member/forms.py:40 member/templates/client/view/information.html:35
+#: forms.py:46 templates/client/view/information.html:39
 msgid "Birthday"
 msgstr "Date de naissance"
 
-#: member/forms.py:46 member/forms.py:254
+#: forms.py:50 forms.py:347 forms.py:497
+msgid "YYYY-MM-DD"
+msgstr ""
+
+#: forms.py:53 forms.py:350 forms.py:500
+msgid "Format: YYYY-MM-DD"
+msgstr ""
+
+#: forms.py:59 forms.py:280
 msgid "Email"
 msgstr "Courriel"
 
-#: member/forms.py:52
+#: forms.py:65
 msgid "Home phone"
 msgstr "Téléphone au domicile"
 
-#: member/forms.py:58 member/forms.py:266
+#: forms.py:71 forms.py:292
 msgid "Cellular"
 msgstr "Cellulaire"
 
-#: member/forms.py:63
-#: member/templates/client/partials/forms/basic_information.html:64
+#: forms.py:76 templates/client/partials/forms/basic_information.html:67
 msgid "Alert"
 msgstr "Alerte"
 
-#: member/forms.py:67
+#: forms.py:80
 msgid "Your message here ..."
 msgstr "Votre message ici ..."
 
-#: member/forms.py:75 member/forms.py:77 member/forms.py:346
-#: member/forms.py:347
+#: forms.py:88
+msgid "At least one contact information is required."
+msgstr "Au moins une information de contact est requise."
+
+#: forms.py:99 forms.py:101 forms.py:395 forms.py:396
 msgid "Apt #"
 msgstr "# Appart."
 
-#: member/forms.py:85
-msgid "Address information"
-msgstr "Adresse civile"
+#: forms.py:109
+msgid "Address Information"
+msgstr "Adresse Civile"
 
-#: member/forms.py:87
+#: forms.py:111
 msgid "7275 Rue Saint-Urbain"
 msgstr ""
 
-#: member/forms.py:94
+#: forms.py:118
 msgid "City"
 msgstr "Ville"
 
-#: member/forms.py:96
+#: forms.py:120
 msgid "Montreal"
 msgstr "Montréal"
 
-#: member/forms.py:103 member/forms.py:357
+#: forms.py:127 forms.py:406
 msgid "Postal Code"
 msgstr "Code Postal"
 
-#: member/forms.py:105
+#: forms.py:129
 msgid "H2R 2Y5"
 msgstr "H2R 2Y5"
 
-#: member/forms.py:111
+#: forms.py:135
 msgid "Latitude"
 msgstr "Latitude"
 
-#: member/forms.py:118
+#: forms.py:142
 msgid "Longitude"
 msgstr "Longitude"
 
-#: member/forms.py:125
+#: forms.py:149
 msgid "Distance from Santropol"
 msgstr "Distance du Santropol Roulant"
 
-#: member/forms.py:132 member/templates/client/list.html:92
-#: member/templates/client/partials/filters.html:16
+#: forms.py:156 templates/client/list.html:102
+#: templates/client/partials/filters.html:16
+#: templates/client/view/information.html:49
 msgid "Route"
 msgstr "Route"
 
-#: member/forms.py:139 member/models.py:471
-#: member/templates/client/view/information.html:40
+#: forms.py:163 models.py:558 templates/client/view/information.html:50
 msgid "Delivery Note"
 msgstr "Notes de Livraison"
 
-#: member/forms.py:143
+#: forms.py:167
 msgid "Delivery Note here ..."
 msgstr "Vos notes de livraison ici ..."
 
-#: member/forms.py:153 member/models.py:38
-#: member/templates/client/partials/forms/meal_prefs.html:6
+#: forms.py:177 models.py:43 templates/client/partials/forms/meal_prefs.html:6
 msgid "Default"
 msgstr "Par Défaut"
 
-#: member/forms.py:170 member/models.py:363
+#: forms.py:196 models.py:448
 msgid "Active"
 msgstr "Actif"
 
-#: member/forms.py:171
+#: forms.py:197
 msgid "By default, the client meal status is Pending."
 msgstr "Par défaut, le statut sera 'En attente'."
 
-#: member/forms.py:176
+#: forms.py:202
 msgid "Type"
 msgstr "Type"
 
-#: member/forms.py:183
+#: forms.py:209
 msgid "Schedule"
 msgstr "Calendrier"
 
-#: member/forms.py:191 member/templates/client/view/allergies.html:32
+#: forms.py:217 templates/client/view/allergies.html:36
 msgid "Restrictions"
 msgstr "Restrictions"
 
-#: member/forms.py:198 member/models.py:61
+#: forms.py:224 models.py:66
 msgid "Preparation"
 msgstr "Préparation"
 
-#: member/forms.py:205
+#: forms.py:231
 msgid "Ingredient To Avoid"
 msgstr "Ingrédients à éviter"
 
-#: member/forms.py:214
+#: forms.py:240
 msgid "Dish(es) To Avoid"
 msgstr "Plats à éviter"
 
-#: member/forms.py:226 member/forms.py:228
+#: forms.py:252 forms.py:254
 msgid "Member"
 msgstr "Membre"
 
-#: member/forms.py:260
+#: forms.py:286
 msgid "Work phone"
 msgstr "Téléphone professionnel"
 
-#: member/forms.py:282
+#: forms.py:308
 msgid "This field is required unless you add a new member."
 msgstr "Ce champ est requis sauf si vous souhaitez ajouter un nouveau membre."
 
-#: member/forms.py:285
+#: forms.py:311 forms.py:363 forms.py:455 forms.py:461
 msgid "This field is required unless you chose an existing member."
 msgstr ""
 "Ce champ est requis à moins que vous ne choisissiez un membre existant."
 
-#: member/forms.py:295
+#: forms.py:321 forms.py:450
 msgid "Not a valid member, please chose an existing member."
 msgstr "Membre non valide. Veuillez choisir un membre existant."
 
-#: member/forms.py:304 member/models.py:916
+#: forms.py:330 models.py:123
 msgid "Work information"
 msgstr "Lieu de travail"
 
-#: member/forms.py:306
+#: forms.py:332
 msgid "Hotel-Dieu, St-Anne Hospital, ..."
 msgstr "Hôtel-Dieu, Hôpital Sainte-Anne, ..."
 
-#: member/forms.py:311 member/templates/client/view/referent.html:31
+#: forms.py:338 templates/client/view/referent.html:36
 msgid "Referral Reason"
 msgstr "Raison du référencement"
 
-#: member/forms.py:316 member/templates/client/view/referent.html:30
+#: forms.py:343 templates/client/view/referent.html:35
 msgid "Referral Date"
 msgstr "Date du référencement"
 
-#: member/forms.py:324
+#: forms.py:372
 msgid "Billing Type"
 msgstr "Type de Facturation"
 
-#: member/forms.py:330
+#: forms.py:378
 msgid "Same As Client"
 msgstr "Identique au Client"
 
-#: member/forms.py:332
+#: forms.py:380
 msgid ""
 "If checked, the personal information             of the client will be used "
 "as billing information."
@@ -216,27 +224,27 @@ msgstr ""
 "Si sélectionné, les informations personnelles du client seront utilisées "
 "pour la facturation.."
 
-#: member/forms.py:338 member/models.py:387
+#: forms.py:386 models.py:472
 msgid "Payment Type"
 msgstr "Type de Paiement"
 
-#: member/forms.py:343
+#: forms.py:392
 msgid "Street Number"
 msgstr "Numéro de rue"
 
-#: member/forms.py:351
+#: forms.py:400
 msgid "Floor"
 msgstr "Étage"
 
-#: member/forms.py:353
+#: forms.py:402
 msgid "Street Name"
 msgstr "Rue"
 
-#: member/forms.py:355
+#: forms.py:404
 msgid "City Name"
 msgstr "Ville"
 
-#: member/forms.py:370
+#: forms.py:419
 msgid ""
 "This member has not a valid address, please add a valid address to this "
 "member, so it can be used for the billing."
@@ -244,321 +252,331 @@ msgstr ""
 "Ce membre ne possède pas une adresse valide. Veillez ajouter une adresse "
 "valide afin qu'elle puisse être utilisée pour la facturation."
 
-#: member/forms.py:375
+#: forms.py:424
 msgid "This field is required"
 msgstr "Ce champ est requis"
 
-#: member/forms.py:387
-msgid "Contact Type"
-msgstr "Type de contact"
-
-#: member/forms.py:392
-msgid "Contact"
-msgstr "Contact"
-
-#: member/forms.py:395 member/templates/client/view/information.html:62
+#: forms.py:436 templates/client/view/information.html:74
 msgid "Relationship"
 msgstr "Lien"
 
-#: member/forms.py:397
+#: forms.py:438
 msgid "Parent, friend, ..."
 msgstr "Parent, ami(e), ..."
 
-#: member/models.py:25
+#: forms.py:468
+msgid "At least one emergency contact is required."
+msgstr "Au moins un contact d'urgence est requis."
+
+#: models.py:30
 msgid "Female"
 msgstr "Femme"
 
-#: member/models.py:26
+#: models.py:31
 msgid "Male"
 msgstr "Homme"
 
-#: member/models.py:27
+#: models.py:32
 msgid "Other"
 msgstr "Autre"
 
-#: member/models.py:39
+#: models.py:44
 msgid "Low income"
 msgstr "Revenu faible"
 
-#: member/models.py:40
+#: models.py:45
 msgid "Solidary"
 msgstr "Solidaire"
 
-#: member/models.py:47
-msgid "Cheque"
-msgstr "Chèque"
+#: models.py:52
+msgid "----"
+msgstr ""
 
-#: member/models.py:48
-msgid "Cash"
-msgstr "Argent"
+#: models.py:53
+msgid "3rd Party"
+msgstr ""
 
-#: member/models.py:49
+#: models.py:54
 msgid "Credit card"
 msgstr "Carte de crédit"
 
-#: member/models.py:50
+#: models.py:55
 msgid "EFT"
 msgstr "TFE"
 
-#: member/models.py:54
+#: models.py:59
 msgid "Ongoing"
 msgstr "Régulier"
 
-#: member/models.py:55
+#: models.py:60
 msgid "Episodic"
 msgstr "Occasionnel"
 
-#: member/models.py:59
+#: models.py:64
 msgid "Main dish size"
 msgstr "Taille du plat principal"
 
-#: member/models.py:60
+#: models.py:65
 msgid "Dish"
 msgstr "Plat"
 
-#: member/models.py:62
+#: models.py:67
 msgid "Other order item"
 msgstr "Autre élément de commande"
 
-#: member/models.py:68
+#: models.py:73
 msgid "Monday"
 msgstr "Lundi"
 
-#: member/models.py:69
+#: models.py:74
 msgid "Tuesday"
 msgstr "Mardi"
 
-#: member/models.py:70
+#: models.py:75
 msgid "Wednesday"
 msgstr "Mercredi"
 
-#: member/models.py:71
+#: models.py:76
 msgid "Thursday"
 msgstr "Jeudi"
 
-#: member/models.py:72
+#: models.py:77
 msgid "Friday"
 msgstr "Vendredi"
 
-#: member/models.py:73
+#: models.py:78
 msgid "Saturday"
 msgstr "Samedi"
 
-#: member/models.py:74
+#: models.py:79
 msgid "Sunday"
 msgstr "Dimanche"
 
-#: member/models.py:81
+#: models.py:84
+msgid "Cycling"
+msgstr ""
+
+#: models.py:85
+msgid "Walking"
+msgstr ""
+
+#: models.py:86
+msgid "Driving"
+msgstr ""
+
+#: models.py:95
 msgid "members"
 msgstr "membres"
 
-#: member/models.py:94
+#: models.py:108
 msgid "firstname"
 msgstr "prénom"
 
-#: member/models.py:99
+#: models.py:113
 msgid "lastname"
 msgstr "nom"
 
-#: member/models.py:104
+#: models.py:118
 msgid "address"
 msgstr "adresse"
 
-#: member/models.py:168
+#: models.py:227
 msgid "addresses"
 msgstr "adresses"
 
-#: member/models.py:172
+#: models.py:231
 msgid "street number"
 msgstr "numéro"
 
-#: member/models.py:179
+#: models.py:238
 msgid "street"
 msgstr "rue"
 
-#: member/models.py:185
+#: models.py:244
 msgid "apartment"
 msgstr "appartement"
 
-#: member/models.py:191
+#: models.py:250
 msgid "floor"
 msgstr "étage"
 
-#: member/models.py:198
+#: models.py:257
 msgid "city"
 msgstr "ville"
 
-#: member/models.py:204
+#: models.py:263
 msgid "postal code"
 msgstr "code postal"
 
-#: member/models.py:235
+#: models.py:294
 msgid "contacts"
 msgstr "contacts"
 
-#: member/models.py:241
+#: models.py:300
 msgid "contact type"
 msgstr "type de contact"
 
-#: member/models.py:246 member/models.py:975
+#: models.py:305 models.py:1096
 msgid "value"
 msgstr "valeur"
 
-#: member/models.py:251 member/models.py:402
+#: models.py:310 models.py:488
 msgid "member"
 msgstr "membre"
 
-#: member/models.py:262
+#: models.py:332
 msgid "Routes"
 msgstr "Routes"
 
-#: member/models.py:268 member/models.py:942
+#: models.py:338 models.py:1063
 msgid "name"
 msgstr "nom"
 
-#: member/models.py:272 member/models.py:946
+#: models.py:342 models.py:1067
 msgid "description"
 msgstr "description"
 
-#: member/models.py:362
+#: models.py:350
+msgid "vehicle"
+msgstr ""
+
+#: models.py:447
 msgid "Pending"
 msgstr "En Attente"
 
-#: member/models.py:364
+#: models.py:449
 msgid "Paused"
 msgstr "Pause"
 
-#: member/models.py:365
+#: models.py:450
 msgid "Stop: no contact"
 msgstr "Stop: pas de contact"
 
-#: member/models.py:366
+#: models.py:451
 msgid "Stop: contact"
 msgstr "Stop: contact"
 
-#: member/models.py:367
+#: models.py:452
 msgid "Deceased"
 msgstr "Décédé"
 
-#: member/models.py:371
+#: models.py:456
 msgid "English"
 msgstr "Anglais"
 
-#: member/models.py:372
+#: models.py:457
 msgid "French"
 msgstr "Français"
 
-#: member/models.py:373
+#: models.py:458
 msgid "Allophone"
 msgstr "Allophone"
 
-#: member/models.py:377
+#: models.py:462
 msgid "clients"
 msgstr "clients"
 
-#: member/models.py:383
+#: models.py:468
 msgid "billing member"
 msgstr "personne à facturer"
 
-#: member/models.py:394
+#: models.py:480
 msgid "rate type"
 msgstr "type de taux"
 
-#: member/models.py:407
+#: models.py:493
 msgid "emergency contact"
 msgstr "contact d'urgence"
 
-#: member/models.py:414
+#: models.py:500
 msgid "emergency contact relationship"
 msgstr "lien avec le contact d'urgence"
 
-#: member/models.py:432
+#: models.py:518
 msgid "alert client"
 msgstr "alerte client"
 
-#: member/models.py:461
+#: models.py:548
 msgid "route"
 msgstr "route"
 
-#: member/models.py:739
+#: models.py:867
 msgid "Start"
 msgstr "Début"
 
-#: member/models.py:740
+#: models.py:868
 msgid "End"
 msgstr "Fin"
 
-#: member/models.py:748
+#: models.py:876
 msgid "To be processed"
 msgstr "À traiter"
 
-#: member/models.py:749
+#: models.py:877
 msgid "Processed"
 msgstr "Traité"
 
-#: member/models.py:750
+#: models.py:878
 msgid "Error"
 msgstr "Erreur"
 
-#: member/models.py:848
+#: models.py:976
 msgid "All"
 msgstr "Tout"
 
-#: member/models.py:861
+#: models.py:989
 msgid "Search by name"
 msgstr "Recherche par nom"
 
-#: member/models.py:902
+#: models.py:1029
 msgid "referents"
 msgstr "référents"
 
-#: member/models.py:905
+#: models.py:1032
 msgid "referent"
 msgstr "référent"
 
-#: member/models.py:908 member/models.py:964 member/models.py:992
-#: member/models.py:1009 member/models.py:1026
+#: models.py:1035 models.py:1085 models.py:1113 models.py:1130 models.py:1147
 msgid "client"
 msgstr "client"
 
-#: member/models.py:912
-#: member/templates/client/partials/forms/referent_information.html:69
+#: models.py:1039 templates/client/partials/forms/referent_information.html:70
 msgid "Referral reason"
 msgstr "Raison du référencement"
 
-#: member/models.py:922
+#: models.py:1043
 msgid "Referral date"
 msgstr "Date du référencement"
 
-#: member/models.py:937
+#: models.py:1058
 msgid "options"
 msgstr "options"
 
-#: member/models.py:954
+#: models.py:1075
 msgid "option group"
 msgstr "groupe d'options"
 
-#: member/models.py:969
+#: models.py:1090
 msgid "option"
 msgstr "option"
 
-#: member/models.py:997
+#: models.py:1118
 msgid "restricted item"
 msgstr "item restreint"
 
-#: member/models.py:1014
+#: models.py:1135
 msgid "ingredient"
 msgstr "ingrédient"
 
-#: member/models.py:1031
+#: models.py:1152
 msgid "component"
 msgstr "composant"
 
-#: member/templates/client/base.html:6
+#: templates/client/base.html:7 templates/client/partials/birthdays.html:8
 msgid "Client"
 msgstr "Client"
 
-#: member/templates/client/base.html:16
+#: templates/client/base.html:18
 #, python-format
 msgid ""
 "\n"
@@ -568,657 +586,720 @@ msgstr ""
 "\n"
 "Client depuis %(created_at)s"
 
-#: member/templates/client/base.html:49
+#: templates/client/base.html:51
 msgid "Important notice"
 msgstr "Remarque importante"
 
-#: member/templates/client/create/form.html:18
+#: templates/client/create/form.html:18
 msgid "Edit existing client"
 msgstr "Modifier un client existant"
 
-#: member/templates/client/create/form.html:18
+#: templates/client/create/form.html:18
 msgid "Create a new client "
 msgstr "Créer un nouveau client"
 
-#: member/templates/client/create/form.html:24
+#: templates/client/create/form.html:24
 msgid "Notice"
 msgstr "Remarque"
 
-#: member/templates/client/create/form.html:26
+#: templates/client/create/form.html:26
 msgid "No information will be saved until all the steps are completed."
 msgstr ""
 "Aucune information ne sera sauvegardée tant que toutes les étapes ne sont "
 "pas complétées."
 
-#: member/templates/client/create/form.html:28
+#: templates/client/create/form.html:28
 msgid "Save as soon as you are ready."
 msgstr "Sauvegarder dès que vous êtes prêts."
 
-#: member/templates/client/create/form.html:38
+#: templates/client/create/form.html:38
 msgid "Edit Client"
 msgstr "Modifier le Client"
 
-#: member/templates/client/create/form.html:38
+#: templates/client/create/form.html:38
 msgid "New Client"
 msgstr "Nouveau client"
 
-#: member/templates/client/create/form.html:44
-#: member/templates/client/partials/menu.html:6
-#: member/templates/client/update/base.html:36
+#: templates/client/create/form.html:44 templates/client/partials/menu.html:10
+#: templates/client/update/base.html:36
 msgid "Personal"
 msgstr "Personnel"
 
-#: member/templates/client/create/form.html:44
-#: member/templates/client/update/base.html:36
+#: templates/client/create/form.html:44 templates/client/update/base.html:36
 msgid "First name, last name, ..."
 msgstr "Prénom, nom de famille, ..."
 
-#: member/templates/client/create/form.html:45
-#: member/templates/client/partials/forms/address_information.html:2
-#: member/templates/client/update/base.html:37
-#: member/templates/client/view/information.html:39
-#: member/templates/client/view/payment.html:41
-#: member/templates/client/view/summary.html:14
+#: templates/client/create/form.html:45
+#: templates/client/partials/forms/address_information.html:2
+#: templates/client/update/base.html:37
+#: templates/client/view/information.html:44
+#: templates/client/view/payment.html:44 templates/client/view/summary.html:14
 msgid "Address"
 msgstr "Adresse"
 
-#: member/templates/client/create/form.html:45
-#: member/templates/client/update/base.html:37
+#: templates/client/create/form.html:45 templates/client/update/base.html:37
 msgid "Street number, city, ..."
 msgstr "Rue, ville, ..."
 
-#: member/templates/client/create/form.html:46
-#: member/templates/client/partials/forms/referent_information.html:2
-#: member/templates/client/partials/menu.html:8
-#: member/templates/client/update/base.html:38
-#: member/templates/client/view/referent.html:16
+#: templates/client/create/form.html:46
+#: templates/client/partials/forms/referent_information.html:2
+#: templates/client/partials/menu.html:12 templates/client/update/base.html:38
+#: templates/client/view/referent.html:19
 msgid "Referent"
 msgstr "Référent"
 
-#: member/templates/client/create/form.html:46
-#: member/templates/client/update/base.html:38
+#: templates/client/create/form.html:46 templates/client/update/base.html:38
 msgid "Referent contact information"
 msgstr "Informations du référent"
 
-#: member/templates/client/create/form.html:47
-#: member/templates/client/update/base.html:39
+#: templates/client/create/form.html:47 templates/client/update/base.html:39
 msgid "Payment"
 msgstr "Paiement"
 
-#: member/templates/client/create/form.html:47
-#: member/templates/client/update/base.html:39
+#: templates/client/create/form.html:47 templates/client/update/base.html:39
 msgid "Payment method, card, ..."
 msgstr "Méthode de paiement, carte, ..."
 
-#: member/templates/client/create/form.html:48
-#: member/templates/client/partials/menu.html:15
-#: member/templates/client/update/base.html:40
+#: templates/client/create/form.html:48 templates/client/partials/menu.html:19
+#: templates/client/update/base.html:40
 msgid "Preferences"
 msgstr "Préférences"
 
-#: member/templates/client/create/form.html:48
-#: member/templates/client/update/base.html:40
+#: templates/client/create/form.html:48 templates/client/update/base.html:40
 msgid "Deliveries, restrictions, ..."
 msgstr "Livraisons, restrictions, ..."
 
-#: member/templates/client/create/form.html:49
-#: member/templates/client/update/base.html:41
+#: templates/client/create/form.html:49 templates/client/update/base.html:41
 msgid "Emergency"
 msgstr "Urgence"
 
-#: member/templates/client/create/form.html:49
-#: member/templates/client/update/base.html:41
+#: templates/client/create/form.html:49 templates/client/update/base.html:41
 msgid "Emergency contact information"
 msgstr "Contact d'urgence"
 
-#: member/templates/client/create/form.html:57
-#: member/templates/client/update/base.html:50
+#: templates/client/create/form.html:57 templates/client/update/base.html:50
 msgid "Required information missing"
 msgstr "Information requise manquante"
 
-#: member/templates/client/create/form.html:58
-#: member/templates/client/update/base.html:51
+#: templates/client/create/form.html:58 templates/client/update/base.html:51
 msgid ""
 "Please review the form to make sure that all required fields are filled."
 msgstr ""
 "Veuillez réviser le formulaire afin de valider que tous les champs requis "
 "sont remplis."
 
-#: member/templates/client/create/form.html:69
-#: member/templates/client/update/base.html:59
+#: templates/client/create/form.html:69 templates/client/update/base.html:59
 msgid "Back"
 msgstr "Précédent"
 
-#: member/templates/client/create/form.html:74
-#: member/templates/client/update/base.html:60
+#: templates/client/create/form.html:74 templates/client/update/base.html:60
 msgid "Save"
 msgstr "Enregistrer"
 
-#: member/templates/client/create/form.html:76
+#: templates/client/create/form.html:76
 msgid "Next"
 msgstr "Suivant"
 
-#: member/templates/client/list.html:5 member/templates/client/list.html:10
-#: member/templates/client/list.html:16
+#: templates/client/list.html:6 templates/client/list.html:11
+#: templates/client/list.html:18
 msgid "Clients"
 msgstr "Clients"
 
-#: member/templates/client/list.html:31
+#: templates/client/list.html:34
 msgid "New client"
 msgstr "Nouveau client"
 
-#: member/templates/client/list.html:34
-#: member/templates/client/partials/forms/emergency_contact.html:13
-#: member/templates/client/partials/forms/payment_information.html:23
-#: member/templates/client/partials/forms/referent_information.html:13
+#: templates/client/list.html:37
+#: templates/client/partials/forms/emergency_contact.html:13
+#: templates/client/partials/forms/payment_information.html:23
+#: templates/client/partials/forms/referent_information.html:13
 msgid "Or"
 msgstr "Ou"
 
-#: member/templates/client/list.html:52 member/templates/client/list.html:99
-#: member/templates/client/view/summary.html:36
+#: templates/client/list.html:56 templates/client/list.html:113
+#: templates/client/view/summary.html:36
 msgid "years old"
 msgstr "ans"
 
-#: member/templates/client/list.html:56
+#: templates/client/list.html:60
 #, python-format
 msgid ""
 "\n"
-"                    %(member_firstname)s is an <strong>%(delivery_type)s</strong> client on the <strong>%(route)s</strong> route.\n"
+"                    %(member_firstname)s is an <strong>%(delivery_type)s</"
+"strong> client on the <strong>%(route)s</strong> route.\n"
 "                "
 msgstr ""
 "\n"
-"                    %(member_firstname)s est un(e) client(e) <strong>%(delivery_type)s</strong> sur la route <strong>%(route)s</strong>.\n"
+"                    %(member_firstname)s est un(e) client(e) <strong>"
+"%(delivery_type)s</strong> sur la route <strong>%(route)s</strong>.\n"
 "                "
 
-#: member/templates/client/list.html:60
+#: templates/client/list.html:64
 msgid "This client is currently"
 msgstr "Le statut du client est"
 
-#: member/templates/client/list.html:80 member/templates/client/list.html:117
+#: templates/client/list.html:84 templates/client/list.html:131
 msgid "Sorry, no result found."
 msgstr "Désolé, aucun résultat trouvé."
 
-#: member/templates/client/list.html:89
-#: member/templates/client/partials/filters.html:7
-#: member/templates/client/partials/forms/basic_information.html:4
-#: member/templates/client/partials/forms/emergency_contact.html:27
-#: member/templates/client/partials/forms/payment_information.html:37
-#: member/templates/client/partials/forms/referent_information.html:26
+#: templates/client/list.html:93 templates/client/partials/filters.html:7
+#: templates/client/partials/forms/basic_information.html:4
+#: templates/client/partials/forms/emergency_contact.html:27
+#: templates/client/partials/forms/payment_information.html:37
+#: templates/client/partials/forms/referent_information.html:26
 msgid "Name"
 msgstr "Nom"
 
-#: member/templates/client/list.html:90
-#: member/templates/client/partials/filters.html:22
-#: member/templates/client/partials/menu.html:11
-#: member/templates/client/view/orders.html:33
+#: templates/client/list.html:94
+msgid "Full name and age of the client."
+msgstr "Nom complet et âge du client."
+
+#: templates/client/list.html:96 templates/client/partials/filters.html:30
+#: templates/client/partials/menu.html:15 templates/client/view/orders.html:35
 msgid "Status"
 msgstr "Statut"
 
-#: member/templates/client/list.html:91
-#: member/templates/client/partials/filters.html:28
-#: member/templates/client/partials/forms/dietary_restriction.html:13
-msgid "Delivery"
-msgstr "Livraison"
+#: templates/client/list.html:97
+msgid ""
+"Meal status. Available status are: Pending, Active, Paused, Stop: no "
+"contact, Stop: contact and Deceased."
+msgstr ""
 
-#: member/templates/client/list.html:93
+#: templates/client/list.html:99 templates/client/view/summary.html:7
+msgid "Delivery type"
+msgstr "Type de Livraison"
+
+#: templates/client/list.html:100
+msgid "A client can be either an ongoing or an episodic client."
+msgstr ""
+
+#: templates/client/list.html:103
+#, fuzzy
+#| msgid "The delivery date planned for the order."
+msgid "The delivery route for the client."
+msgstr "Date de livraison prévue pour la commande"
+
+#: templates/client/list.html:105
 msgid "Last update"
 msgstr "Dernière modification"
 
-#: member/templates/client/list.html:131
+#: templates/client/list.html:106
+#, fuzzy
+#| msgid "Contact information of the client"
+msgid "Last modification of the file."
+msgstr "Coordonnées du client"
+
+#: templates/client/list.html:145
 msgid "of"
 msgstr ""
 
-#: member/templates/client/partials/birthdays.html:3
+#: templates/client/partials/birthdays.html:3
 msgid "Happy Birthday"
 msgstr "Bonne Fête"
 
-#: member/templates/client/partials/filters.html:36
-#: member/templates/client/view/notes.html:47
-#: member/templates/client/view/status.html:33
+#: templates/client/partials/birthdays.html:9
+msgid "Age"
+msgstr ""
+
+#: templates/client/partials/birthdays.html:10
+#: templates/client/view/status.html:42
+msgid "Date"
+msgstr "Date"
+
+#: templates/client/partials/birthdays.html:25
+#, python-format
+msgid "%(count)s birthday."
+msgid_plural "%(count)s birthdays."
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/client/partials/filters.html:22
+#: templates/client/partials/forms/dietary_restriction.html:13
+msgid "Delivery"
+msgstr "Livraison"
+
+#: templates/client/partials/filters.html:36
+#: templates/client/view/notes.html:49 templates/client/view/status.html:33
 msgid "Reset"
 msgstr "Réinitialiser"
 
-#: member/templates/client/partials/filters.html:37
-#: member/templates/client/view/notes.html:48
+#: templates/client/partials/filters.html:37
+#: templates/client/view/notes.html:50
 msgid "Search"
 msgstr "Recherche"
 
-#: member/templates/client/partials/forms/address_information.html:27
+#: templates/client/partials/forms/address_information.html:27
 msgid "Geolocation"
 msgstr "Localisation"
 
-#: member/templates/client/partials/forms/address_information.html:31
+#: templates/client/partials/forms/address_information.html:30
+#, fuzzy
+#| msgid "Address information"
+msgid "Address not Found !!"
+msgstr "Adresse civile"
+
+#: templates/client/partials/forms/address_information.html:31
 msgid "Geolocate"
 msgstr "Localiser"
 
-#: member/templates/client/partials/forms/address_information.html:50
+#: templates/client/partials/forms/address_information.html:33
+#, fuzzy
+#| msgid "Geolocation"
+msgid "Geolocation is mandatory."
+msgstr "Localisation"
+
+#: templates/client/partials/forms/address_information.html:49
 msgid "km"
 msgstr "km"
 
-#: member/templates/client/partials/forms/address_information.html:60
+#: templates/client/partials/forms/address_information.html:59
 msgid "Delivery Route"
 msgstr "Route de Livraison"
 
-#: member/templates/client/partials/forms/basic_information.html:2
+#: templates/client/partials/forms/basic_information.html:2
 msgid "Identity"
 msgstr "Identité"
 
-#: member/templates/client/partials/forms/basic_information.html:31
-#: member/templates/client/partials/forms/basic_information.html:40
-#: member/templates/client/partials/forms/emergency_contact.html:43
+#: templates/client/partials/forms/basic_information.html:34
+#: templates/client/partials/forms/basic_information.html:43
+#: templates/client/partials/forms/emergency_contact.html:37
 msgid "Contact information"
 msgstr "Information de contact"
 
-#: member/templates/client/partials/forms/basic_information.html:67
+#: templates/client/partials/forms/basic_information.html:70
 msgid "This message will be hightlighted on the client record."
 msgstr "Ce message sera affiché sur la fiche client."
 
-#: member/templates/client/partials/forms/dietary_restriction.html:2
-#: member/templates/client/view/allergies.html:27
+#: templates/client/partials/forms/dietary_restriction.html:2
+#: templates/client/view/allergies.html:31
 msgid "Meal status"
 msgstr "Statut de livraison"
 
-#: member/templates/client/partials/forms/dietary_restriction.html:33
-#: member/templates/client/view/allergies.html:9
+#: templates/client/partials/forms/dietary_restriction.html:33
+#: templates/client/view/allergies.html:10
 msgid "Food preferences"
 msgstr "Préférences alimentaires    "
 
-#: member/templates/client/partials/forms/emergency_contact.html:2
+#: templates/client/partials/forms/emergency_contact.html:2
 msgid "Emergency contact"
 msgstr "Contact d'urgence"
 
-#: member/templates/client/partials/forms/emergency_contact.html:16
+#: templates/client/partials/forms/emergency_contact.html:16
 msgid "Create new emergency contact"
 msgstr "Créer un contact d'urgence"
 
-#: member/templates/client/partials/forms/emergency_contact.html:52
+#: templates/client/partials/forms/emergency_contact.html:65
 msgid "Contact relationship"
 msgstr "Relation de contact"
 
-#: member/templates/client/partials/forms/meal_defaults.html:16
-#: member/templates/client/partials/forms/meal_prefs.html:12
-#: member/templates/client/partials/meal_defaults.html:13
+#: templates/client/partials/forms/meal_defaults.html:16
+#: templates/client/partials/forms/meal_prefs.html:12
+#: templates/client/partials/meal_defaults.html:13
 msgid "Size"
 msgstr "Taille"
 
-#: member/templates/client/partials/forms/meal_defaults.html:17
-#: member/templates/client/partials/forms/meal_prefs.html:13
-#: member/templates/client/partials/meal_defaults.html:14
+#: templates/client/partials/forms/meal_defaults.html:17
+#: templates/client/partials/forms/meal_prefs.html:13
+#: templates/client/partials/meal_defaults.html:14
 msgid "Component"
 msgstr "Composant"
 
-#: member/templates/client/partials/forms/meal_defaults.html:18
-#: member/templates/client/partials/forms/meal_prefs.html:14
-#: member/templates/client/partials/meal_defaults.html:15
+#: templates/client/partials/forms/meal_defaults.html:18
+#: templates/client/partials/forms/meal_prefs.html:14
+#: templates/client/partials/meal_defaults.html:15
 msgid "Quantity"
 msgstr "Quantité"
 
-#: member/templates/client/partials/forms/payment_information.html:2
+#: templates/client/partials/forms/payment_information.html:2
 msgid "Billing information"
 msgstr "Information de facturation"
 
-#: member/templates/client/partials/forms/payment_information.html:26
+#: templates/client/partials/forms/payment_information.html:26
 msgid "Create new payment member"
 msgstr "Ajouter un nouveau membre à facturer"
 
-#: member/templates/client/partials/forms/payment_information.html:49
+#: templates/client/partials/forms/payment_information.html:49
 msgid "Street"
 msgstr "Rue"
 
-#: member/templates/client/partials/forms/referent_information.html:16
+#: templates/client/partials/forms/referent_information.html:16
 msgid "Create new referent member"
 msgstr "Ajouter un nouveau référent"
 
-#: member/templates/client/partials/forms/referent_information.html:83
+#: templates/client/partials/forms/referent_information.html:84
 msgid "Please describe the referral reason(s)"
 msgstr "Veuillez décrire les raisons pour lesquelles le client est référé"
 
-#: member/templates/client/partials/menu.html:4
-#: member/templates/client/view/information.html:8
-#: member/templates/client/view/notes.html:8
-#: member/templates/client/view/status.html:8
+#: templates/client/partials/menu.html:8
+#: templates/client/view/information.html:9 templates/client/view/notes.html:9
+#: templates/client/view/status.html:8
 msgid "Information"
 msgstr "Information"
 
-#: member/templates/client/partials/menu.html:9
+#: templates/client/partials/menu.html:13
 msgid "Add a referent"
 msgstr "Ajouter un référent"
 
-#: member/templates/client/partials/menu.html:9
+#: templates/client/partials/menu.html:13
 msgid "No referent available"
 msgstr "Pas de référent"
 
-#: member/templates/client/partials/menu.html:10
-#: member/templates/client/view/payment.html:17
+#: templates/client/partials/menu.html:14 templates/client/view/payment.html:19
 msgid "Billing"
 msgstr "Facturation"
 
-#: member/templates/client/partials/menu.html:19
+#: templates/client/partials/menu.html:23
 msgid "Notes"
 msgstr "Notes"
 
-#: member/templates/client/partials/menu.html:23
-#: member/templates/client/view/orders.html:18
+#: templates/client/partials/menu.html:27 templates/client/view/orders.html:20
 msgid "Orders"
 msgstr "Commandes"
 
-#: member/templates/client/update/base.html:14
-#: member/templates/client/update/base.html:30
+#: templates/client/partials/prefs.html:15
+#, fuzzy
+#| msgid "Delivery"
+msgid "No delivery."
+msgstr "Livraison"
+
+#: templates/client/update/base.html:14 templates/client/update/base.html:30
 msgid "Update Client"
 msgstr "Mise à jour du client"
 
-#: member/templates/client/update/base.html:20
+#: templates/client/update/base.html:20
 msgid "Tip"
 msgstr "Astuce"
 
-#: member/templates/client/update/base.html:21
+#: templates/client/update/base.html:21
 msgid "In update mode, each step can be saved individually"
 msgstr "Pour la mise à jour, chaque étape peut être enregistré séparément"
 
-#: member/templates/client/update/status.html:3
+#: templates/client/update/status.html:3
 msgid "Status modification"
 msgstr "Changement de statut"
 
-#: member/templates/client/update/status.html:20
+#: templates/client/update/status.html:20
 msgid ""
 "If you want to schedule a status modification, feel free to fill one or two "
 "of theses date fields."
 msgstr ""
-"Pour planifier une modification de statut, veuillez de remplir les champs de"
-" dates ci-dessous"
+"Pour planifier une modification de statut, veuillez de remplir les champs de "
+"dates ci-dessous"
 
-#: member/templates/client/update/status.html:33
+#: templates/client/update/status.html:33
 msgid "End date"
 msgstr "Date de fin"
 
-#: member/templates/client/update/status.html:45
+#: templates/client/update/status.html:45
 msgid "Cancel"
 msgstr "Annuler"
 
-#: member/templates/client/update/status.html:46
+#: templates/client/update/status.html:46
 msgid "OK"
 msgstr "Ok"
 
-#: member/templates/client/view/allergies.html:17
+#: templates/client/view/allergies.html:19
 msgid "Meal information"
 msgstr "Information sur le repas"
 
-#: member/templates/client/view/allergies.html:18
+#: templates/client/view/allergies.html:20
 msgid "Meal information of the referent person"
 msgstr ""
 
-#: member/templates/client/view/allergies.html:21
-#: member/templates/client/view/allergies.html:96
-#: member/templates/client/view/information.html:24
-#: member/templates/client/view/information.html:54
-#: member/templates/client/view/payment.html:23
-#: member/templates/client/view/referent.html:21
+#: templates/client/view/allergies.html:24
+#: templates/client/view/allergies.html:101
+#: templates/client/view/information.html:27
+#: templates/client/view/information.html:65
+#: templates/client/view/payment.html:26 templates/client/view/referent.html:25
 msgid "Edit"
 msgstr "Éditer"
 
-#: member/templates/client/view/allergies.html:41
+#: templates/client/view/allergies.html:45
 msgid "Yipee! No restriction"
 msgstr "Parfait! Aucune restriction"
 
-#: member/templates/client/view/allergies.html:46
+#: templates/client/view/allergies.html:50
 msgid "Food preparation"
 msgstr "Préparation de la nourriture"
 
-#: member/templates/client/view/allergies.html:55
+#: templates/client/view/allergies.html:59
 msgid "Nope! Nothing specific"
 msgstr "Rien à signaler!"
 
-#: member/templates/client/view/allergies.html:60
+#: templates/client/view/allergies.html:64
 msgid "Ingredients to avoid"
 msgstr "Ingrédients à éviter"
 
-#: member/templates/client/view/allergies.html:69
-#: member/templates/client/view/allergies.html:83
+#: templates/client/view/allergies.html:73
+#: templates/client/view/allergies.html:87
 msgid "Yeah! Likes everything"
 msgstr "Parfait! Aucune restriction"
 
-#: member/templates/client/view/allergies.html:74
+#: templates/client/view/allergies.html:78
 msgid "Dish(es) to avoid"
 msgstr "Plats à éviter"
 
-#: member/templates/client/view/allergies.html:92
+#: templates/client/view/allergies.html:96
 msgid "Meal schedule"
 msgstr "Calendrier des repas"
 
-#: member/templates/client/view/allergies.html:93
+#: templates/client/view/allergies.html:97
 msgid "Meal default schedule of the referent person"
 msgstr ""
 
-#: member/templates/client/view/information.html:17
+#: templates/client/view/information.html:19
 msgid "Basic information"
 msgstr "Informations de base"
 
-#: member/templates/client/view/information.html:19
+#: templates/client/view/information.html:21
 msgid "Contact information of the client"
 msgstr "Coordonnées du client"
 
-#: member/templates/client/view/information.html:32
+#: templates/client/view/information.html:36
 msgid "Gender"
 msgstr "Sexe"
 
-#: member/templates/client/view/information.html:33
-#: member/templates/client/view/summary.html:28
+#: templates/client/view/information.html:37
+#: templates/client/view/summary.html:28
 msgid "Language"
 msgstr "Langue"
 
-#: member/templates/client/view/information.html:34
+#: templates/client/view/information.html:38
 msgid "Delivery Type"
 msgstr "Type de Livraison"
 
-#: member/templates/client/view/information.html:49
+#: templates/client/view/information.html:59
 msgid "Emergency Contact"
 msgstr "Contact d'Urgence"
 
-#: member/templates/client/view/information.html:50
+#: templates/client/view/information.html:60
 msgid "Information of the person to contact in case of an emergency"
 msgstr "Information sur la personne contact en cas d'urgence"
 
-#: member/templates/client/view/notes.html:17
+#: templates/client/view/notes.html:19
 msgid "Staff Notes"
 msgstr "Notes du Staff"
 
-#: member/templates/client/view/notes.html:19
+#: templates/client/view/notes.html:21
 msgid "Notes added to"
 msgstr "Notes ajoutées à"
 
-#: member/templates/client/view/notes.html:19
+#: templates/client/view/notes.html:21
 msgid "s file"
 msgstr ""
 
-#: member/templates/client/view/notes.html:31
+#: templates/client/view/notes.html:33
 msgid "Priority"
 msgstr "Priorité"
 
-#: member/templates/client/view/notes.html:38
+#: templates/client/view/notes.html:40
 msgid "Is read"
 msgstr "Lu"
 
-#: member/templates/client/view/notes.html:68
+#: templates/client/view/notes.html:53
+#, fuzzy
+#| msgid "Notes"
+msgid "New Note"
+msgstr "Notes"
+
+#: templates/client/view/notes.html:75
 msgid "Done/Read"
 msgstr "Fait/Lu"
 
-#: member/templates/client/view/notes.html:71
+#: templates/client/view/notes.html:78
 msgid "New"
 msgstr "Nouveau"
 
-#: member/templates/client/view/orders.html:8
+#: templates/client/view/orders.html:9
 msgid "Orders list"
 msgstr "Liste des commandes"
 
-#: member/templates/client/view/orders.html:19
+#: templates/client/view/orders.html:21
 msgid "List of all orders from"
 msgstr "Liste de toutes les commandes depuis"
 
-#: member/templates/client/view/orders.html:27
+#: templates/client/view/orders.html:29
 msgid "Order"
 msgstr "Commande"
 
-#: member/templates/client/view/orders.html:28
+#: templates/client/view/orders.html:30
 msgid "A unique identifier for the order."
 msgstr "Identifiant unique de la commande."
 
-#: member/templates/client/view/orders.html:30
+#: templates/client/view/orders.html:32
 msgid "Delivery Date"
 msgstr "Date de Livraison"
 
-#: member/templates/client/view/orders.html:31
+#: templates/client/view/orders.html:33
 msgid "The delivery date planned for the order."
 msgstr "Date de livraison prévue pour la commande"
 
-#: member/templates/client/view/orders.html:34
+#: templates/client/view/orders.html:36
 msgid "The order status"
 msgstr "statut de la commande"
 
-#: member/templates/client/view/orders.html:36
+#: templates/client/view/orders.html:38
 msgid "Amount"
 msgstr "Montant"
 
-#: member/templates/client/view/orders.html:37
+#: templates/client/view/orders.html:39
 msgid "Total amount in $CAD."
 msgstr "Montant total en $CAD"
 
-#: member/templates/client/view/orders.html:39
+#: templates/client/view/orders.html:41
 msgid "Actions"
 msgstr "Actions"
 
-#: member/templates/client/view/payment.html:8
-#: member/templates/client/view/referent.html:8
+#: templates/client/view/payment.html:9 templates/client/view/referent.html:9
 msgid "Referent information"
 msgstr "Informations du référent"
 
-#: member/templates/client/view/payment.html:18
+#: templates/client/view/payment.html:20
 msgid "Billing and payment information"
 msgstr "Information de facturation"
 
-#: member/templates/client/view/payment.html:34
+#: templates/client/view/payment.html:38
 msgid "Payment method"
 msgstr "Méthode de paiement"
 
-#: member/templates/client/view/payment.html:37
+#: templates/client/view/payment.html:41
 msgid "Rate type"
 msgstr "Type de taux"
 
-#: member/templates/client/view/referent.html:17
+#: templates/client/view/referent.html:20
 msgid "Contact information of the referent person"
 msgstr "Coordonnées de la personne référente"
 
-#: member/templates/client/view/referent.html:29
+#: templates/client/view/referent.html:34
 msgid "Workplace information"
 msgstr "Lieu de travail"
 
-#: member/templates/client/view/status.html:17
+#: templates/client/view/status.html:17
 msgid "Scheduled status modifications"
 msgstr "Changement(s) de statut planifié(s)"
 
-#: member/templates/client/view/status.html:19
+#: templates/client/view/status.html:19
 msgid "Here are listed all scheduled status modifications."
 msgstr "Voici l'historique des changements de statut."
 
-#: member/templates/client/view/status.html:34
+#: templates/client/view/status.html:34
 msgid "Apply"
 msgstr "Appliquer"
 
-#: member/templates/client/view/status.html:42
-msgid "Date"
-msgstr "Date"
-
-#: member/templates/client/view/status.html:43
+#: templates/client/view/status.html:43
 msgid "From"
 msgstr "De"
 
-#: member/templates/client/view/status.html:44
+#: templates/client/view/status.html:44
 msgid "To"
 msgstr "À"
 
-#: member/templates/client/view/status.html:45
+#: templates/client/view/status.html:45
 msgid "Reason"
 msgstr "Raison"
 
-#: member/templates/client/view/status.html:46
+#: templates/client/view/status.html:46
 msgid "Operation status"
 msgstr "Statut"
 
-#: member/templates/client/view/status.html:52
+#: templates/client/view/status.html:52
 msgid "No status modification."
 msgstr "Aucun changement de statut."
 
-#: member/templates/client/view/summary.html:7
-msgid "Delivery type"
-msgstr "Type de Livraison"
-
-#: member/templates/client/view/summary.html:21
+#: templates/client/view/summary.html:21
 msgid "Home"
 msgstr "Domicile"
 
-#: member/urls.py:57
+#: templatetags/member_extras.py:34
+#, python-format
+msgid "%(count)s %(size)s %(component_label)s"
+msgstr ""
+
+#: templatetags/member_extras.py:39
+#, python-format
+msgid "%(count)s %(component_label)s"
+msgstr ""
+
+#: urls.py:57
 msgid "^view/(?P<pk>\\d+)/$"
 msgstr ""
 
-#: member/urls.py:58
+#: urls.py:58
 msgid "^view/(?P<pk>\\d+)/orders$"
 msgstr ""
 
-#: member/urls.py:60
+#: urls.py:60
 msgid "^view/(?P<pk>\\d+)/information$"
 msgstr ""
 
-#: member/urls.py:62
+#: urls.py:62
 msgid "^view/(?P<pk>\\d+)/referent$"
 msgstr ""
 
-#: member/urls.py:64
+#: urls.py:64
 msgid "^view/(?P<pk>\\d+)/billing$"
 msgstr ""
 
-#: member/urls.py:66
+#: urls.py:66
 msgid "^view/(?P<pk>\\d+)/preferences$"
 msgstr ""
 
-#: member/urls.py:68
+#: urls.py:68
 msgid "^view/(?P<pk>\\d+)/notes$"
 msgstr ""
 
-#: member/urls.py:70
+#: urls.py:70
+msgid "^view/(?P<pk>\\d+)/notes/add$"
+msgstr ""
+
+#: urls.py:72
 msgid "^geolocateAddress/$"
 msgstr ""
 
-#: member/urls.py:71
+#: urls.py:73
 msgid "^view/(?P<pk>\\d+)/status$"
 msgstr ""
 
-#: member/urls.py:75
+#: urls.py:77
 msgid "^restriction/(?P<pk>\\d+)/delete/$"
 msgstr ""
 
-#: member/urls.py:77
+#: urls.py:79
 msgid "^client_option/(?P<pk>\\d+)/delete/$"
 msgstr ""
 
-#: member/urls.py:79
+#: urls.py:81
 msgid "^ingredient_to_avoid/(?P<pk>\\d+)/delete/$"
 msgstr ""
 
-#: member/urls.py:81
+#: urls.py:83
 msgid "^component_to_avoid/(?P<pk>\\d+)/delete/$"
 msgstr ""
 
-#: member/urls.py:102
+#: urls.py:104
 msgid "^(?P<pk>\\d+)/update/{}/$"
 msgstr ""
 
-#: member/views.py:89
+#: views.py:95
 msgid "The client has been created"
 msgstr "Le client a été crée"
 
-#: member/views.py:842
+#: views.py:832
 msgid "The client has been updated"
 msgstr "Le client a été mis à jour"
 
-#: member/views.py:1355
+#: views.py:1402
 msgid "The status has been changed"
 msgstr "Le statut a été changé"
+
+#~ msgid "Contact Type"
+#~ msgstr "Type de contact"
+
+#~ msgid "Contact"
+#~ msgstr "Contact"
+
+#~ msgid "Cheque"
+#~ msgstr "Chèque"
+
+#~ msgid "Cash"
+#~ msgstr "Argent"

--- a/src/member/templates/client/partials/forms/address_information.html
+++ b/src/member/templates/client/partials/forms/address_information.html
@@ -27,7 +27,7 @@
 <h4 class="ui dividing header">{% trans 'Geolocation' %}</h4>
 
 <div class="field">
-    <button id="geocodeBtn" type="button" class="ui labeled icon right yellow big button">
+    <button id="geocodeBtn" type="button" class="ui labeled icon right yellow big button" data-not-found-msg="{% trans 'Address not Found !!' %}">
       <i class="marker icon"></i>{% trans 'Geolocate' %}
     </button>
     <i class="help-text question yellow icon link" data-content="{% trans 'Geolocation is mandatory.' %}"></i>

--- a/src/page/locale/en/LC_MESSAGES/django.po
+++ b/src/page/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-01-12 16:31+0000\n"
+"POT-Creation-Date: 2017-03-01 14:07-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,43 +17,43 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: page/templates/pages/card.html:11
+#: templates/pages/card.html:11
 msgid "Joined in 2010"
 msgstr ""
 
-#: page/templates/pages/card.html:14
+#: templates/pages/card.html:14
 msgid "Katrina is the coordinator of the clients system"
 msgstr ""
 
-#: page/templates/pages/home.html:7
+#: templates/pages/home.html:7
 msgid "Homepage"
 msgstr ""
 
-#: page/templates/pages/home.html:20
+#: templates/pages/home.html:20
 msgid "Clients"
 msgstr ""
 
-#: page/templates/pages/home.html:28
+#: templates/pages/home.html:28
 msgid "Active clients"
 msgstr ""
 
-#: page/templates/pages/home.html:33
+#: templates/pages/home.html:33
 msgid "clients are"
 msgstr ""
 
-#: page/templates/pages/home.html:33
+#: templates/pages/home.html:33
 msgid "pending"
 msgstr ""
 
-#: page/templates/pages/home.html:40
+#: templates/pages/home.html:40
 msgid "Delivered this month"
 msgstr ""
 
-#: page/templates/pages/home.html:48
+#: templates/pages/home.html:48
 msgid "Orders"
 msgstr ""
 
-#: page/templates/pages/home.html:54
+#: templates/pages/home.html:54
 #, python-format
 msgid ""
 "\n"
@@ -61,26 +61,38 @@ msgid ""
 "                        "
 msgstr ""
 
-#: page/templates/pages/home.html:64
+#: templates/pages/home.html:64
 msgid "Routes"
 msgstr ""
 
-#: page/templates/pages/home.html:86
+#: templates/pages/home.html:86
 #, python-format
 msgid "%(count)s route."
 msgid_plural "%(count)s routes."
 msgstr[0] ""
 msgstr[1] ""
 
-#: page/templates/registration/login.html:8
-#: page/templates/registration/login.html:37
+#: templates/registration/login.html:8 templates/registration/login.html:42
 msgid "Login"
 msgstr ""
 
-#: page/templates/registration/login.html:14
+#: templates/registration/login.html:14
 msgid "Log-in to your account"
 msgstr ""
 
-#: page/templates/registration/login.html:48
+#: templates/registration/login.html:20
+msgid "Please enter a username"
+msgstr ""
+
+#: templates/registration/login.html:21
+msgid "Please enter a password"
+msgstr ""
+
+#: templates/registration/login.html:22
+#, python-brace-format
+msgid "Your password must be at least {ruleValue} characters"
+msgstr ""
+
+#: templates/registration/login.html:53
 msgid "Connect"
 msgstr ""

--- a/src/page/locale/fr/LC_MESSAGES/django.po
+++ b/src/page/locale/fr/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-01-12 16:31+0000\n"
+"POT-Creation-Date: 2017-03-01 14:07-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: PascalPriori <pascal.priori@savoirfairelinux.com>, 2016\n"
 "Language-Team: French (https://www.transifex.com/savoirfairelinux/"
@@ -19,43 +19,43 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: page/templates/pages/card.html:11
+#: templates/pages/card.html:11
 msgid "Joined in 2010"
 msgstr ""
 
-#: page/templates/pages/card.html:14
+#: templates/pages/card.html:14
 msgid "Katrina is the coordinator of the clients system"
 msgstr ""
 
-#: page/templates/pages/home.html:7
+#: templates/pages/home.html:7
 msgid "Homepage"
 msgstr "Page d’accueil"
 
-#: page/templates/pages/home.html:20
+#: templates/pages/home.html:20
 msgid "Clients"
 msgstr "Clients"
 
-#: page/templates/pages/home.html:28
+#: templates/pages/home.html:28
 msgid "Active clients"
 msgstr "Clients actifs"
 
-#: page/templates/pages/home.html:33
+#: templates/pages/home.html:33
 msgid "clients are"
 msgstr "Clients sont"
 
-#: page/templates/pages/home.html:33
+#: templates/pages/home.html:33
 msgid "pending"
 msgstr "En attente"
 
-#: page/templates/pages/home.html:40
+#: templates/pages/home.html:40
 msgid "Delivered this month"
 msgstr ""
 
-#: page/templates/pages/home.html:48
+#: templates/pages/home.html:48
 msgid "Orders"
 msgstr "Commandes"
 
-#: page/templates/pages/home.html:54
+#: templates/pages/home.html:54
 #, python-format
 msgid ""
 "\n"
@@ -63,27 +63,39 @@ msgid ""
 "                        "
 msgstr ""
 
-#: page/templates/pages/home.html:64
+#: templates/pages/home.html:64
 msgid "Routes"
 msgstr ""
 
-#: page/templates/pages/home.html:86
+#: templates/pages/home.html:86
 #, python-format
 msgid "%(count)s route."
 msgid_plural "%(count)s routes."
 msgstr[0] ""
 msgstr[1] ""
 
-#: page/templates/registration/login.html:8
-#: page/templates/registration/login.html:37
+#: templates/registration/login.html:8 templates/registration/login.html:42
 msgid "Login"
 msgstr "Identifiant"
 
-#: page/templates/registration/login.html:14
+#: templates/registration/login.html:14
 msgid "Log-in to your account"
 msgstr "Se connecter à son compte"
 
-#: page/templates/registration/login.html:48
+#: templates/registration/login.html:20
+msgid "Please enter a username"
+msgstr "Merci d'entrer un nom d'utilisateur"
+
+#: templates/registration/login.html:21
+msgid "Please enter a password"
+msgstr "Merci d'entrer un mot de passe"
+
+#: templates/registration/login.html:22
+#, python-brace-format
+msgid "Your password must be at least {ruleValue} characters"
+msgstr "Votre mot de passe doit comporter au moins {ruleValue} caractères"
+
+#: templates/registration/login.html:53
 msgid "Connect"
 msgstr "Connexion"
 

--- a/src/page/templates/registration/login.html
+++ b/src/page/templates/registration/login.html
@@ -16,7 +16,12 @@
 </h2>
 
 {% if not user.username %}
-<form method="post" action='' class="ui large form">{% csrf_token%}
+<form method="post" action='' class="ui large form"
+    data-username-empty-msg="{% trans 'Please enter a username' %}"
+    data-password-empty-msg="{% trans 'Please enter a password' %}"
+    data-password-min-length-msg="{% trans 'Your password must be at least {ruleValue} characters' %}"
+    >
+    {% csrf_token%}
     <div class="ui error message"></div>
     <div class="ui stacked segment">
         <div class="field">


### PR DESCRIPTION
## Fixes # by aaboffill

### Changes proposed in this pull request:

* Added HTML data attributes to replace the text directly appended into the `JS` files. 

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

* Introduce a wrong address into the client form and press the Geolocate button.
* Try to login to the site and keep empty the form fields.

### New translatable strings

- [X] If applicable, I have included updated .po files with new strings (see http://goo.gl/kfBO7N)
