### PR TITLE
Improved usability of meal admin

### DIFF
--- a/src/delivery/fixtures/sample_data.json
+++ b/src/delivery/fixtures/sample_data.json
@@ -1729,7 +1729,7 @@
         "model": "member.client",
         "fields": {
             "emergency_contact_relationship": "Friend",
-            "route": 1,
+            "route": 3,
             "billing_payment_type": "check",
             "gender": "M",
             "delivery_note": "",
@@ -1974,7 +1974,7 @@
         "pk": 509,
         "model": "member.client_option",
         "fields": {
-            "value": "cut-up meat",
+            "value": "X",
             "client": 608,
             "option": 889
         }
@@ -2040,6 +2040,15 @@
             "value": "[\"monday\", \"tuesday\", \"wednesday\", \"thursday\", \"friday\", \"saturday\", \"sunday\"]",
             "client": 612,
             "option": 1
+        }
+    },
+    {
+        "pk": 517,
+        "model": "member.client_option",
+        "fields": {
+            "value": "X",
+            "client": 611,
+            "option": 889
         }
     },
     {
@@ -2111,7 +2120,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Dairy",
+            "ingredient_group": "dairy",
             "name": "Butter"
         }
     },
@@ -2120,7 +2129,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Dairy",
+            "ingredient_group": "dairy",
             "name": "Cheese : Blue cheese"
         }
     },
@@ -2129,7 +2138,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Dairy",
+            "ingredient_group": "dairy",
             "name": "Cheese : Bocconcini"
         }
     },
@@ -2138,7 +2147,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Dairy",
+            "ingredient_group": "dairy",
             "name": "Cheese : Cheddar"
         }
     },
@@ -2147,7 +2156,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Dairy",
+            "ingredient_group": "dairy",
             "name": "Cheese : Cottage cheese"
         }
     },
@@ -2156,7 +2165,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Dairy",
+            "ingredient_group": "dairy",
             "name": "Cheese : Feta"
         }
     },
@@ -2165,7 +2174,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Dairy",
+            "ingredient_group": "dairy",
             "name": "Cheese : Goat cheese"
         }
     },
@@ -2174,7 +2183,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Dairy",
+            "ingredient_group": "dairy",
             "name": "Cheese : Mozzarella"
         }
     },
@@ -2183,7 +2192,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Dairy",
+            "ingredient_group": "dairy",
             "name": "Cheese : Parmesan"
         }
     },
@@ -2192,7 +2201,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Dairy",
+            "ingredient_group": "dairy",
             "name": "Cheese : Ricotta"
         }
     },
@@ -2201,7 +2210,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Dairy",
+            "ingredient_group": "dairy",
             "name": "Eggs"
         }
     },
@@ -2210,7 +2219,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Dairy",
+            "ingredient_group": "dairy",
             "name": "Margarine"
         }
     },
@@ -2219,7 +2228,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Dairy",
+            "ingredient_group": "dairy",
             "name": "Milk"
         }
     },
@@ -2228,7 +2237,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Dairy",
+            "ingredient_group": "dairy",
             "name": "Tofu"
         }
     },
@@ -2237,7 +2246,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Dairy",
+            "ingredient_group": "dairy",
             "name": "Yogurt"
         }
     },
@@ -2246,7 +2255,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Dry and Canned goods",
+            "ingredient_group": "dry_and_canned_goods",
             "name": "Almond Powder "
         }
     },
@@ -2255,7 +2264,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Dry and Canned goods",
+            "ingredient_group": "dry_and_canned_goods",
             "name": "Almonds"
         }
     },
@@ -2264,7 +2273,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Dry and Canned goods",
+            "ingredient_group": "dry_and_canned_goods",
             "name": "Capers"
         }
     },
@@ -2273,7 +2282,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Dry and Canned goods",
+            "ingredient_group": "dry_and_canned_goods",
             "name": "Corn meal"
         }
     },
@@ -2282,7 +2291,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Dry and Canned goods",
+            "ingredient_group": "dry_and_canned_goods",
             "name": "corn starch"
         }
     },
@@ -2291,7 +2300,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Dry and Canned goods",
+            "ingredient_group": "dry_and_canned_goods",
             "name": "Creamed corn"
         }
     },
@@ -2300,7 +2309,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Dry and Canned goods",
+            "ingredient_group": "dry_and_canned_goods",
             "name": "Egg noodles"
         }
     },
@@ -2309,7 +2318,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Dry and Canned goods",
+            "ingredient_group": "dry_and_canned_goods",
             "name": "Linguini"
         }
     },
@@ -2318,7 +2327,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Dry and Canned goods",
+            "ingredient_group": "dry_and_canned_goods",
             "name": "peanut butter"
         }
     },
@@ -2327,7 +2336,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Dry and Canned goods",
+            "ingredient_group": "dry_and_canned_goods",
             "name": "peanuts "
         }
     },
@@ -2336,7 +2345,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Dry and Canned goods",
+            "ingredient_group": "dry_and_canned_goods",
             "name": "Pickles"
         }
     },
@@ -2345,7 +2354,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Dry and Canned goods",
+            "ingredient_group": "dry_and_canned_goods",
             "name": "Polenta"
         }
     },
@@ -2354,7 +2363,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Dry and Canned goods",
+            "ingredient_group": "dry_and_canned_goods",
             "name": "Rice noodles"
         }
     },
@@ -2363,7 +2372,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Dry and Canned goods",
+            "ingredient_group": "dry_and_canned_goods",
             "name": "sesame seeds"
         }
     },
@@ -2372,7 +2381,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Dry and Canned goods",
+            "ingredient_group": "dry_and_canned_goods",
             "name": "Sunflower seeds"
         }
     },
@@ -2381,7 +2390,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Dry and Canned goods",
+            "ingredient_group": "dry_and_canned_goods",
             "name": "Tomato paste"
         }
     },
@@ -2390,7 +2399,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Dry and Canned goods",
+            "ingredient_group": "dry_and_canned_goods",
             "name": "Walnuts"
         }
     },
@@ -2399,7 +2408,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Dry and Canned goods",
+            "ingredient_group": "dry_and_canned_goods",
             "name": "Whole wheat lasagna"
         }
     },
@@ -2408,7 +2417,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Dry and Canned goods",
+            "ingredient_group": "dry_and_canned_goods",
             "name": "Whole wheat linguini "
         }
     },
@@ -2417,7 +2426,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Dry and Canned goods",
+            "ingredient_group": "dry_and_canned_goods",
             "name": "Whole wheat macaroni"
         }
     },
@@ -2426,7 +2435,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Dry and Canned goods",
+            "ingredient_group": "dry_and_canned_goods",
             "name": "Whole wheat penne "
         }
     },
@@ -2435,7 +2444,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Dry and Canned goods",
+            "ingredient_group": "dry_and_canned_goods",
             "name": "Whole wheat spaghetti"
         }
     },
@@ -2444,7 +2453,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Fish",
+            "ingredient_group": "fish",
             "name": "Canned salmon"
         }
     },
@@ -2453,7 +2462,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Fish",
+            "ingredient_group": "fish",
             "name": "Canned tuna"
         }
     },
@@ -2462,7 +2471,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Fish",
+            "ingredient_group": "fish",
             "name": "Cod"
         }
     },
@@ -2471,7 +2480,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Fish",
+            "ingredient_group": "fish",
             "name": "Haddock"
         }
     },
@@ -2480,7 +2489,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Fish",
+            "ingredient_group": "fish",
             "name": "Pollock"
         }
     },
@@ -2489,7 +2498,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Fresh herbs",
+            "ingredient_group": "fresh_herbs",
             "name": "Basil"
         }
     },
@@ -2498,7 +2507,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Fresh herbs",
+            "ingredient_group": "fresh_herbs",
             "name": "Chives"
         }
     },
@@ -2507,7 +2516,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Fresh herbs",
+            "ingredient_group": "fresh_herbs",
             "name": "Cilantro"
         }
     },
@@ -2516,7 +2525,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Fresh herbs",
+            "ingredient_group": "fresh_herbs",
             "name": "Dill"
         }
     },
@@ -2525,7 +2534,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Fresh herbs",
+            "ingredient_group": "fresh_herbs",
             "name": "Marjoram"
         }
     },
@@ -2534,7 +2543,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Fresh herbs",
+            "ingredient_group": "fresh_herbs",
             "name": "Oregano"
         }
     },
@@ -2543,7 +2552,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Fresh herbs",
+            "ingredient_group": "fresh_herbs",
             "name": "Parsley"
         }
     },
@@ -2552,7 +2561,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Fresh herbs",
+            "ingredient_group": "fresh_herbs",
             "name": "Rosemary"
         }
     },
@@ -2561,7 +2570,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Fresh herbs",
+            "ingredient_group": "fresh_herbs",
             "name": "Thyme"
         }
     },
@@ -2570,7 +2579,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Grains",
+            "ingredient_group": "grains",
             "name": "Barley (gluten)"
         }
     },
@@ -2579,7 +2588,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Grains",
+            "ingredient_group": "grains",
             "name": "Basmati rice"
         }
     },
@@ -2588,7 +2597,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Grains",
+            "ingredient_group": "grains",
             "name": "Breadcrumbs"
         }
     },
@@ -2597,7 +2606,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Grains",
+            "ingredient_group": "grains",
             "name": "Brown rice"
         }
     },
@@ -2606,7 +2615,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Grains",
+            "ingredient_group": "grains",
             "name": "Buckwheat"
         }
     },
@@ -2615,7 +2624,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Grains",
+            "ingredient_group": "grains",
             "name": "Couscous (gluten)"
         }
     },
@@ -2624,7 +2633,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Grains",
+            "ingredient_group": "grains",
             "name": "Millet"
         }
     },
@@ -2633,7 +2642,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Grains",
+            "ingredient_group": "grains",
             "name": "Oats"
         }
     },
@@ -2642,7 +2651,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Grains",
+            "ingredient_group": "grains",
             "name": "Quinoa"
         }
     },
@@ -2651,7 +2660,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Grains",
+            "ingredient_group": "grains",
             "name": "White flour"
         }
     },
@@ -2660,7 +2669,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Grains",
+            "ingredient_group": "grains",
             "name": "Whole wheat flour"
         }
     },
@@ -2669,7 +2678,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Grains",
+            "ingredient_group": "grains",
             "name": "Wild rice"
         }
     },
@@ -2678,7 +2687,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Legumineuse",
+            "ingredient_group": "legumineuse",
             "name": "Black beans"
         }
     },
@@ -2687,7 +2696,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Legumineuse",
+            "ingredient_group": "legumineuse",
             "name": "Chickpeas"
         }
     },
@@ -2696,7 +2705,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Legumineuse",
+            "ingredient_group": "legumineuse",
             "name": "Kidney beans"
         }
     },
@@ -2705,7 +2714,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Legumineuse",
+            "ingredient_group": "legumineuse",
             "name": "Lentils"
         }
     },
@@ -2714,7 +2723,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Legumineuse",
+            "ingredient_group": "legumineuse",
             "name": "White beans"
         }
     },
@@ -2723,7 +2732,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Meat",
+            "ingredient_group": "meat",
             "name": "Beef cubes"
         }
     },
@@ -2732,7 +2741,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Meat",
+            "ingredient_group": "meat",
             "name": "Chicken"
         }
     },
@@ -2741,7 +2750,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Meat",
+            "ingredient_group": "meat",
             "name": "Chicken thighs"
         }
     },
@@ -2750,7 +2759,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Meat",
+            "ingredient_group": "meat",
             "name": "Ground beef"
         }
     },
@@ -2759,7 +2768,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Meat",
+            "ingredient_group": "meat",
             "name": "Ground porc"
         }
     },
@@ -2768,7 +2777,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Meat",
+            "ingredient_group": "meat",
             "name": "Ham"
         }
     },
@@ -2777,7 +2786,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Meat",
+            "ingredient_group": "meat",
             "name": "Lamb cubes"
         }
     },
@@ -2786,7 +2795,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Meat",
+            "ingredient_group": "meat",
             "name": "Pork sausage"
         }
     },
@@ -2795,7 +2804,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Meat",
+            "ingredient_group": "meat",
             "name": "Pork toulouse sausage"
         }
     },
@@ -2804,7 +2813,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Meat",
+            "ingredient_group": "meat",
             "name": "Roast Beef "
         }
     },
@@ -2813,7 +2822,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Meat",
+            "ingredient_group": "meat",
             "name": "stock"
         }
     },
@@ -2822,7 +2831,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Meat",
+            "ingredient_group": "meat",
             "name": "Turkey"
         }
     },
@@ -2831,7 +2840,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Meat",
+            "ingredient_group": "meat",
             "name": "Turkey thighs"
         }
     },
@@ -2840,7 +2849,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Oils and Sauces",
+            "ingredient_group": "oils_and_sauces",
             "name": "Apple cider vinegar"
         }
     },
@@ -2849,7 +2858,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Oils and Sauces",
+            "ingredient_group": "oils_and_sauces",
             "name": "Balsamic vinegar"
         }
     },
@@ -2858,7 +2867,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Oils and Sauces",
+            "ingredient_group": "oils_and_sauces",
             "name": "cooking wine"
         }
     },
@@ -2867,7 +2876,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Oils and Sauces",
+            "ingredient_group": "oils_and_sauces",
             "name": "Dijon mustard"
         }
     },
@@ -2876,7 +2885,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Oils and Sauces",
+            "ingredient_group": "oils_and_sauces",
             "name": "honey"
         }
     },
@@ -2885,7 +2894,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Oils and Sauces",
+            "ingredient_group": "oils_and_sauces",
             "name": "maple sirop"
         }
     },
@@ -2894,7 +2903,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Oils and Sauces",
+            "ingredient_group": "oils_and_sauces",
             "name": "Olive oil"
         }
     },
@@ -2903,7 +2912,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Oils and Sauces",
+            "ingredient_group": "oils_and_sauces",
             "name": "Prepared mustard"
         }
     },
@@ -2912,7 +2921,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Oils and Sauces",
+            "ingredient_group": "oils_and_sauces",
             "name": "Red wine (salt)"
         }
     },
@@ -2921,7 +2930,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Oils and Sauces",
+            "ingredient_group": "oils_and_sauces",
             "name": "Red wine vinegar"
         }
     },
@@ -2930,7 +2939,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Oils and Sauces",
+            "ingredient_group": "oils_and_sauces",
             "name": "Rice vinegar "
         }
     },
@@ -2939,7 +2948,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Oils and Sauces",
+            "ingredient_group": "oils_and_sauces",
             "name": "rice wine vinegar"
         }
     },
@@ -2948,7 +2957,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Oils and Sauces",
+            "ingredient_group": "oils_and_sauces",
             "name": "Sesame oil"
         }
     },
@@ -2957,7 +2966,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Oils and Sauces",
+            "ingredient_group": "oils_and_sauces",
             "name": "Soy sauce (gluten, salt)"
         }
     },
@@ -2966,7 +2975,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Oils and Sauces",
+            "ingredient_group": "oils_and_sauces",
             "name": "Vinegar"
         }
     },
@@ -2975,7 +2984,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Oils and Sauces",
+            "ingredient_group": "oils_and_sauces",
             "name": "White wine"
         }
     },
@@ -2984,7 +2993,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Seafood",
+            "ingredient_group": "seafood",
             "name": "Seafood medley (shrimp, mussels, calamari)"
         }
     },
@@ -2993,7 +3002,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Seafood",
+            "ingredient_group": "seafood",
             "name": "Shrimp"
         }
     },
@@ -3002,7 +3011,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Spices",
+            "ingredient_group": "spices",
             "name": "Allspice"
         }
     },
@@ -3011,7 +3020,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Spices",
+            "ingredient_group": "spices",
             "name": "Bay leaves"
         }
     },
@@ -3020,7 +3029,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Spices",
+            "ingredient_group": "spices",
             "name": "Black pepper"
         }
     },
@@ -3029,7 +3038,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Spices",
+            "ingredient_group": "spices",
             "name": "Cardamom"
         }
     },
@@ -3038,7 +3047,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Spices",
+            "ingredient_group": "spices",
             "name": "Chili"
         }
     },
@@ -3047,7 +3056,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Spices",
+            "ingredient_group": "spices",
             "name": "Cinnamon"
         }
     },
@@ -3056,7 +3065,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Spices",
+            "ingredient_group": "spices",
             "name": "Cloves"
         }
     },
@@ -3065,7 +3074,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Spices",
+            "ingredient_group": "spices",
             "name": "Coriander"
         }
     },
@@ -3074,7 +3083,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Spices",
+            "ingredient_group": "spices",
             "name": "Cumin"
         }
     },
@@ -3083,7 +3092,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Spices",
+            "ingredient_group": "spices",
             "name": "Curry"
         }
     },
@@ -3092,7 +3101,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Spices",
+            "ingredient_group": "spices",
             "name": "Ginger powder"
         }
     },
@@ -3101,7 +3110,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Spices",
+            "ingredient_group": "spices",
             "name": "Herbes de provence"
         }
     },
@@ -3110,7 +3119,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Spices",
+            "ingredient_group": "spices",
             "name": "Mustard powder"
         }
     },
@@ -3119,7 +3128,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Spices",
+            "ingredient_group": "spices",
             "name": "Nutmeg"
         }
     },
@@ -3128,7 +3137,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Spices",
+            "ingredient_group": "spices",
             "name": "Paprika"
         }
     },
@@ -3137,7 +3146,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Spices",
+            "ingredient_group": "spices",
             "name": "Sage"
         }
     },
@@ -3146,7 +3155,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Spices",
+            "ingredient_group": "spices",
             "name": "Terragon"
         }
     },
@@ -3155,7 +3164,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Spices",
+            "ingredient_group": "spices",
             "name": "Turmeric"
         }
     },
@@ -3164,7 +3173,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Veggies & Fruits",
+            "ingredient_group": "veggies_and_fruits",
             "name": "Apples"
         }
     },
@@ -3173,7 +3182,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Veggies & Fruits",
+            "ingredient_group": "veggies_and_fruits",
             "name": "Apricots"
         }
     },
@@ -3182,7 +3191,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Veggies & Fruits",
+            "ingredient_group": "veggies_and_fruits",
             "name": "Arugula"
         }
     },
@@ -3191,7 +3200,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Veggies & Fruits",
+            "ingredient_group": "veggies_and_fruits",
             "name": "Artichokes"
         }
     },
@@ -3200,7 +3209,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Veggies & Fruits",
+            "ingredient_group": "veggies_and_fruits",
             "name": "Bean sprouts"
         }
     },
@@ -3209,7 +3218,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Veggies & Fruits",
+            "ingredient_group": "veggies_and_fruits",
             "name": "Beets"
         }
     },
@@ -3218,7 +3227,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Veggies & Fruits",
+            "ingredient_group": "veggies_and_fruits",
             "name": "Bok choy"
         }
     },
@@ -3227,7 +3236,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Veggies & Fruits",
+            "ingredient_group": "veggies_and_fruits",
             "name": "Broccoli"
         }
     },
@@ -3236,7 +3245,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Veggies & Fruits",
+            "ingredient_group": "veggies_and_fruits",
             "name": "Brussel sprouts"
         }
     },
@@ -3245,7 +3254,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Veggies & Fruits",
+            "ingredient_group": "veggies_and_fruits",
             "name": "Cabbage"
         }
     },
@@ -3254,7 +3263,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Veggies & Fruits",
+            "ingredient_group": "veggies_and_fruits",
             "name": "Carrots"
         }
     },
@@ -3263,7 +3272,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Veggies & Fruits",
+            "ingredient_group": "veggies_and_fruits",
             "name": "Cauliflower"
         }
     },
@@ -3272,7 +3281,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Veggies & Fruits",
+            "ingredient_group": "veggies_and_fruits",
             "name": "celery"
         }
     },
@@ -3281,7 +3290,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Veggies & Fruits",
+            "ingredient_group": "veggies_and_fruits",
             "name": "Celery root"
         }
     },
@@ -3290,7 +3299,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Veggies & Fruits",
+            "ingredient_group": "veggies_and_fruits",
             "name": "Chicory"
         }
     },
@@ -3299,7 +3308,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Veggies & Fruits",
+            "ingredient_group": "veggies_and_fruits",
             "name": "Corn"
         }
     },
@@ -3308,7 +3317,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Veggies & Fruits",
+            "ingredient_group": "veggies_and_fruits",
             "name": "Cranberries"
         }
     },
@@ -3317,7 +3326,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Veggies & Fruits",
+            "ingredient_group": "veggies_and_fruits",
             "name": "Cucumber"
         }
     },
@@ -3326,7 +3335,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Veggies & Fruits",
+            "ingredient_group": "veggies_and_fruits",
             "name": "Eggplant"
         }
     },
@@ -3335,7 +3344,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Veggies & Fruits",
+            "ingredient_group": "veggies_and_fruits",
             "name": "Garlic"
         }
     },
@@ -3344,7 +3353,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Veggies & Fruits",
+            "ingredient_group": "veggies_and_fruits",
             "name": "Ginger"
         }
     },
@@ -3353,7 +3362,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Veggies & Fruits",
+            "ingredient_group": "veggies_and_fruits",
             "name": "Green beans"
         }
     },
@@ -3362,7 +3371,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Veggies & Fruits",
+            "ingredient_group": "veggies_and_fruits",
             "name": "Green peas"
         }
     },
@@ -3371,7 +3380,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Veggies & Fruits",
+            "ingredient_group": "veggies_and_fruits",
             "name": "Green peppers"
         }
     },
@@ -3380,7 +3389,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Veggies & Fruits",
+            "ingredient_group": "veggies_and_fruits",
             "name": "Kale"
         }
     },
@@ -3389,7 +3398,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Veggies & Fruits",
+            "ingredient_group": "veggies_and_fruits",
             "name": "Kolhrabi"
         }
     },
@@ -3398,7 +3407,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Veggies & Fruits",
+            "ingredient_group": "veggies_and_fruits",
             "name": "Leeks"
         }
     },
@@ -3407,7 +3416,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Veggies & Fruits",
+            "ingredient_group": "veggies_and_fruits",
             "name": "Lemons"
         }
     },
@@ -3416,7 +3425,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Veggies & Fruits",
+            "ingredient_group": "veggies_and_fruits",
             "name": "Lettuce"
         }
     },
@@ -3425,7 +3434,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Veggies & Fruits",
+            "ingredient_group": "veggies_and_fruits",
             "name": "lime"
         }
     },
@@ -3434,7 +3443,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Veggies & Fruits",
+            "ingredient_group": "veggies_and_fruits",
             "name": "mung bean sprouts"
         }
     },
@@ -3443,7 +3452,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Veggies & Fruits",
+            "ingredient_group": "veggies_and_fruits",
             "name": "Mushrooms"
         }
     },
@@ -3452,7 +3461,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Veggies & Fruits",
+            "ingredient_group": "veggies_and_fruits",
             "name": "Olives"
         }
     },
@@ -3461,7 +3470,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Veggies & Fruits",
+            "ingredient_group": "veggies_and_fruits",
             "name": "Onions"
         }
     },
@@ -3470,7 +3479,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Veggies & Fruits",
+            "ingredient_group": "veggies_and_fruits",
             "name": "Orange peppers"
         }
     },
@@ -3479,7 +3488,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Veggies & Fruits",
+            "ingredient_group": "veggies_and_fruits",
             "name": "parsnip"
         }
     },
@@ -3488,7 +3497,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Veggies & Fruits",
+            "ingredient_group": "veggies_and_fruits",
             "name": "Potatoes"
         }
     },
@@ -3497,7 +3506,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Veggies & Fruits",
+            "ingredient_group": "veggies_and_fruits",
             "name": "Pumpkin"
         }
     },
@@ -3506,7 +3515,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Veggies & Fruits",
+            "ingredient_group": "veggies_and_fruits",
             "name": "Radish"
         }
     },
@@ -3515,7 +3524,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Veggies & Fruits",
+            "ingredient_group": "veggies_and_fruits",
             "name": "Raisins"
         }
     },
@@ -3524,7 +3533,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Veggies & Fruits",
+            "ingredient_group": "veggies_and_fruits",
             "name": "Red peppers  "
         }
     },
@@ -3533,7 +3542,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Veggies & Fruits",
+            "ingredient_group": "veggies_and_fruits",
             "name": "Snap peas"
         }
     },
@@ -3542,7 +3551,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Veggies & Fruits",
+            "ingredient_group": "veggies_and_fruits",
             "name": "Snow peas"
         }
     },
@@ -3551,7 +3560,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Veggies & Fruits",
+            "ingredient_group": "veggies_and_fruits",
             "name": "Spinach"
         }
     },
@@ -3560,7 +3569,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Veggies & Fruits",
+            "ingredient_group": "veggies_and_fruits",
             "name": "squash"
         }
     },
@@ -3569,7 +3578,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Veggies & Fruits",
+            "ingredient_group": "veggies_and_fruits",
             "name": "Sweet potatoes"
         }
     },
@@ -3578,7 +3587,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Veggies & Fruits",
+            "ingredient_group": "veggies_and_fruits",
             "name": "Swiss chard"
         }
     },
@@ -3587,7 +3596,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Veggies & Fruits",
+            "ingredient_group": "veggies_and_fruits",
             "name": "Tomatoes"
         }
     },
@@ -3596,7 +3605,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Veggies & Fruits",
+            "ingredient_group": "veggies_and_fruits",
             "name": "Turnips"
         }
     },
@@ -3605,7 +3614,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Veggies & Fruits",
+            "ingredient_group": "veggies_and_fruits",
             "name": "Yellow beans"
         }
     },
@@ -3614,7 +3623,7 @@
         "model": "meal.ingredient",
         "fields": {
             "description": null,
-            "ingredient_group": "Veggies & Fruits",
+            "ingredient_group": "veggies_and_fruits",
             "name": "zucchini"
         }
     },
@@ -8574,7 +8583,7 @@
         "fields": {
             "description": "",
             "name": "fish",
-            "restricted_item_group": "fish&seafood"
+            "restricted_item_group": "seafood"
         }
     },
     {
@@ -8583,7 +8592,7 @@
         "fields": {
             "description": "",
             "name": "seafood",
-            "restricted_item_group": "fish&seafood"
+            "restricted_item_group": "seafood"
         }
     },
     {
@@ -8646,7 +8655,7 @@
         "fields": {
             "description": "",
             "name": "nuts ",
-            "restricted_item_group": "nuts&seeds"
+            "restricted_item_group": "seeds and nuts"
         }
     },
     {
@@ -8655,7 +8664,7 @@
         "fields": {
             "description": "",
             "name": "peanut butter",
-            "restricted_item_group": "nuts&seeds"
+            "restricted_item_group": "seeds and nuts"
         }
     },
     {
@@ -8664,7 +8673,7 @@
         "fields": {
             "description": "gluten, salt",
             "name": "peanuts",
-            "restricted_item_group": "nuts&seeds"
+            "restricted_item_group": "seeds and nuts"
         }
     },
     {
@@ -8673,7 +8682,7 @@
         "fields": {
             "description": "text",
             "name": "seeds",
-            "restricted_item_group": "nuts&seeds"
+            "restricted_item_group": "seeds and nuts"
         }
     },
     {
@@ -15951,15 +15960,6 @@
         }
     },
     {
-        "model": "member.client_option",
-        "pk": 101,
-        "fields": {
-            "client": 101,
-            "option": 195,
-            "value": "X"
-        }
-    },
-    {
         "model": "member.restriction",
         "pk": 101,
         "fields": {
@@ -16124,14 +16124,6 @@
         }
     },
     {
-        "model": "member.client_avoid_ingredient",
-        "pk": 103,
-        "fields": {
-            "client": 103,
-            "ingredient": 3388
-        }
-    },
-    {
         "model": "member.member",
         "pk": 104,
         "fields": {
@@ -16182,15 +16174,6 @@
             "client": 104,
             "referral_reason": "Needs help.",
             "date": "2016-12-21"
-        }
-    },
-    {
-        "model": "member.client_option",
-        "pk": 104,
-        "fields": {
-            "client": 104,
-            "option": 195,
-            "value": "X"
         }
     },
     {
@@ -16325,7 +16308,7 @@
             "delivery_type": "O",
             "gender": "M",
             "birthdate": "1941-11-12",
-            "route": 196,
+            "route": 3,
             "meal_default_week": "{\n  \"compote_friday_quantity\": 1,\n  \"compote_monday_quantity\": 1,\n  \"compote_saturday_quantity\": 1,\n  \"compote_sunday_quantity\": 1,\n  \"compote_thursday_quantity\": 1,\n  \"compote_tuesday_quantity\": 1,\n  \"compote_wednesday_quantity\": 1,\n  \"dessert_friday_quantity\": 0,\n  \"dessert_monday_quantity\": 0,\n  \"dessert_saturday_quantity\": 0,\n  \"dessert_sunday_quantity\": 0,\n  \"dessert_thursday_quantity\": 0,\n  \"dessert_tuesday_quantity\": 0,\n  \"dessert_wednesday_quantity\": 0,\n  \"diabetic_dessert_friday_quantity\": 0,\n  \"diabetic_dessert_monday_quantity\": 0,\n  \"diabetic_dessert_saturday_quantity\": 0,\n  \"diabetic_dessert_sunday_quantity\": 0,\n  \"diabetic_dessert_thursday_quantity\": 0,\n  \"diabetic_dessert_tuesday_quantity\": 0,\n  \"diabetic_dessert_wednesday_quantity\": 0,\n  \"fruit_salad_friday_quantity\": 0,\n  \"fruit_salad_monday_quantity\": 0,\n  \"fruit_salad_saturday_quantity\": 0,\n  \"fruit_salad_sunday_quantity\": 0,\n  \"fruit_salad_thursday_quantity\": 0,\n  \"fruit_salad_tuesday_quantity\": 0,\n  \"fruit_salad_wednesday_quantity\": 0,\n  \"green_salad_friday_quantity\": 0,\n  \"green_salad_monday_quantity\": 0,\n  \"green_salad_saturday_quantity\": 0,\n  \"green_salad_sunday_quantity\": 0,\n  \"green_salad_thursday_quantity\": 0,\n  \"green_salad_tuesday_quantity\": 0,\n  \"green_salad_wednesday_quantity\": 0,\n  \"main_dish_friday_quantity\": 1,\n  \"main_dish_monday_quantity\": 1,\n  \"main_dish_saturday_quantity\": 1,\n  \"main_dish_sunday_quantity\": 1,\n  \"main_dish_thursday_quantity\": 1,\n  \"main_dish_tuesday_quantity\": 1,\n  \"main_dish_wednesday_quantity\": 1,\n  \"pudding_friday_quantity\": 0,\n  \"pudding_monday_quantity\": 0,\n  \"pudding_saturday_quantity\": 0,\n  \"pudding_sunday_quantity\": 0,\n  \"pudding_thursday_quantity\": 0,\n  \"pudding_tuesday_quantity\": 0,\n  \"pudding_wednesday_quantity\": 0,\n  \"size_friday\": \"R\",\n  \"size_monday\": \"R\",\n  \"size_saturday\": \"R\",\n  \"size_sunday\": \"R\",\n  \"size_thursday\": \"R\",\n  \"size_tuesday\": \"R\",\n  \"size_wednesday\": \"R\"\n}",
             "delivery_note": "Ring door bell many times."
         }
@@ -16436,14 +16419,6 @@
         }
     },
     {
-        "model": "member.client_avoid_ingredient",
-        "pk": 107,
-        "fields": {
-            "client": 107,
-            "ingredient": 3388
-        }
-    },
-    {
         "model": "member.member",
         "pk": 108,
         "fields": {
@@ -16494,15 +16469,6 @@
             "client": 108,
             "referral_reason": "Needs help.",
             "date": "2016-12-21"
-        }
-    },
-    {
-        "model": "member.client_option",
-        "pk": 108,
-        "fields": {
-            "client": 108,
-            "option": 195,
-            "value": "X"
         }
     },
     {
@@ -16592,14 +16558,6 @@
         }
     },
     {
-        "model": "member.client_avoid_ingredient",
-        "pk": 109,
-        "fields": {
-            "client": 109,
-            "ingredient": 3388
-        }
-    },
-    {
         "model": "member.member",
         "pk": 110,
         "fields": {
@@ -16650,15 +16608,6 @@
             "client": 110,
             "referral_reason": "Needs help.",
             "date": "2016-12-21"
-        }
-    },
-    {
-        "model": "member.client_option",
-        "pk": 110,
-        "fields": {
-            "client": 110,
-            "option": 195,
-            "value": "X"
         }
     },
     {

--- a/src/meal/admin.py
+++ b/src/meal/admin.py
@@ -1,7 +1,8 @@
 from django.contrib import admin
-from meal.models import Component, Restricted_item
-from meal.models import Ingredient, Component_ingredient
-from meal.models import Incompatibility, Menu, Menu_component
+from django.db.models.functions import Lower
+from meal.models import (Component, Restricted_item,
+                         Ingredient, Component_ingredient,
+                         Incompatibility, Menu, Menu_component)
 
 
 class ComponentsInline(admin.TabularInline):
@@ -10,6 +11,10 @@ class ComponentsInline(admin.TabularInline):
 
 class ComponentIngredientInline(admin.TabularInline):
     model = Component_ingredient
+
+
+class IncompatibilityInline(admin.TabularInline):
+    model = Incompatibility
 
 
 class MenuAdmin(admin.ModelAdmin):
@@ -24,10 +29,35 @@ class ComponentAdmin(admin.ModelAdmin):
     inlines = [
         ComponentIngredientInline
     ]
+    list_display = ('name', 'component_group')
+    search_fields = ['name', 'component_group']
+
+    def get_ordering(self, request):
+        return [Lower('name')]
+
+
+class IngredientAdmin(admin.ModelAdmin):
+    """Allows more control over the display of ingredients in the admin."""
+    list_display = ('name', 'ingredient_group',)
+    search_fields = ['name', 'ingredient_group']
+
+    def get_ordering(self, request):
+        return [Lower('name')]
+
+
+class Restricted_itemAdmin(admin.ModelAdmin):
+    """Allows accessing ingredients within the Restricted_item admin."""
+    inlines = [
+        IncompatibilityInline
+    ]
+    list_display = ('name', 'restricted_item_group',)
+    search_fields = ['name', 'restricted_item_group']
+
+    def get_ordering(self, request):
+        return [Lower('name')]
 
 
 admin.site.register(Component, ComponentAdmin)
-admin.site.register(Restricted_item)
-admin.site.register(Ingredient)
-admin.site.register(Incompatibility)
+admin.site.register(Restricted_item, Restricted_itemAdmin)
+admin.site.register(Ingredient, IngredientAdmin)
 admin.site.register(Menu, MenuAdmin)

--- a/src/meal/admin.py
+++ b/src/meal/admin.py
@@ -2,7 +2,10 @@ from django.contrib import admin
 from django.db.models.functions import Lower
 from meal.models import (Component, Restricted_item,
                          Ingredient, Component_ingredient,
-                         Incompatibility, Menu, Menu_component)
+                         Incompatibility, Menu, Menu_component,
+                         COMPONENT_GROUP_CHOICES,
+                         INGREDIENT_GROUP_CHOICES,
+                         RESTRICTED_ITEM_GROUP_CHOICES)
 
 
 class ComponentsInline(admin.TabularInline):
@@ -30,19 +33,43 @@ class ComponentAdmin(admin.ModelAdmin):
         ComponentIngredientInline
     ]
     list_display = ('name', 'component_group')
-    search_fields = ['name', 'component_group']
+    search_fields = ('name',)
 
     def get_ordering(self, request):
         return [Lower('name')]
+
+    def get_search_results(self, request, queryset, search_term):
+        # search for group choices in their display value instead of DB value
+        queryset, use_distinct = super().get_search_results(
+            request, queryset, search_term)
+        search_list = [choice[0] for
+                       choice in COMPONENT_GROUP_CHOICES
+                       if search_term in choice[1]]
+        if search_list:
+            queryset |= self.model.objects.filter(
+                component_group__in=search_list)
+        return queryset, use_distinct
 
 
 class IngredientAdmin(admin.ModelAdmin):
     """Allows more control over the display of ingredients in the admin."""
     list_display = ('name', 'ingredient_group',)
-    search_fields = ['name', 'ingredient_group']
+    search_fields = ('name',)
 
     def get_ordering(self, request):
         return [Lower('name')]
+
+    def get_search_results(self, request, queryset, search_term):
+        # search for group choices in their display value instead of DB value
+        queryset, use_distinct = super().get_search_results(
+            request, queryset, search_term)
+        search_list = [choice[0] for
+                       choice in INGREDIENT_GROUP_CHOICES
+                       if search_term in choice[1]]
+        if search_list:
+            queryset |= self.model.objects.filter(
+                ingredient_group__in=search_list)
+        return queryset, use_distinct
 
 
 class Restricted_itemAdmin(admin.ModelAdmin):
@@ -51,11 +78,22 @@ class Restricted_itemAdmin(admin.ModelAdmin):
         IncompatibilityInline
     ]
     list_display = ('name', 'restricted_item_group',)
-    search_fields = ['name', 'restricted_item_group']
+    search_fields = ('name',)
 
     def get_ordering(self, request):
         return [Lower('name')]
 
+    def get_search_results(self, request, queryset, search_term):
+        # search for group choices in their display value instead of DB value
+        queryset, use_distinct = super().get_search_results(
+            request, queryset, search_term)
+        search_list = [choice[0] for
+                       choice in RESTRICTED_ITEM_GROUP_CHOICES
+                       if search_term in choice[1]]
+        if search_list:
+            queryset |= self.model.objects.filter(
+                restricted_item_group__in=search_list)
+        return queryset, use_distinct
 
 admin.site.register(Component, ComponentAdmin)
 admin.site.register(Restricted_item, Restricted_itemAdmin)

--- a/src/meal/admin.py
+++ b/src/meal/admin.py
@@ -44,7 +44,7 @@ class ComponentAdmin(admin.ModelAdmin):
             request, queryset, search_term)
         search_list = [choice[0] for
                        choice in COMPONENT_GROUP_CHOICES
-                       if search_term in choice[1]]
+                       if search_term.lower() in choice[1].lower()]
         if search_list:
             queryset |= self.model.objects.filter(
                 component_group__in=search_list)
@@ -65,7 +65,7 @@ class IngredientAdmin(admin.ModelAdmin):
             request, queryset, search_term)
         search_list = [choice[0] for
                        choice in INGREDIENT_GROUP_CHOICES
-                       if search_term in choice[1]]
+                       if search_term.lower() in choice[1].lower()]
         if search_list:
             queryset |= self.model.objects.filter(
                 ingredient_group__in=search_list)
@@ -89,7 +89,7 @@ class Restricted_itemAdmin(admin.ModelAdmin):
             request, queryset, search_term)
         search_list = [choice[0] for
                        choice in RESTRICTED_ITEM_GROUP_CHOICES
-                       if search_term in choice[1]]
+                       if search_term.lower() in choice[1].lower()]
         if search_list:
             queryset |= self.model.objects.filter(
                 restricted_item_group__in=search_list)

--- a/src/meal/locale/fr/LC_MESSAGES/django.po
+++ b/src/meal/locale/fr/LC_MESSAGES/django.po
@@ -120,7 +120,7 @@ msgstr "groupe d'ingrédients"
 
 #: meal/models.py:69
 msgid "components"
-msgstr "composants"
+msgstr "composants (Plats et recettes)"
 
 #: meal/models.py:87
 msgid "component group"
@@ -140,11 +140,11 @@ msgstr "date"
 
 #: meal/models.py:141
 msgid "restricted items"
-msgstr "Aliment avec restrictions"
+msgstr "Catégories de restrictions"
 
 #: meal/models.py:159
 msgid "restricted item group"
-msgstr "groupe d'aliment avec restrictions"
+msgstr "Type de catégorie de restrictions"
 
 #: meal/models.py:175
 msgid "restricted item"

--- a/src/meal/models.py
+++ b/src/meal/models.py
@@ -68,7 +68,7 @@ class Ingredient(models.Model):
 class Component(models.Model):
 
     class Meta:
-        verbose_name_plural = _('components')
+        verbose_name_plural = _('components (Dishes and recipes)')
 
     # Meal component (ex. main dish, vegetable, seasonal) information
     name = models.CharField(
@@ -142,7 +142,7 @@ class Component_ingredient(models.Model):
 class Restricted_item(models.Model):
 
     class Meta:
-        verbose_name_plural = _('restricted items')
+        verbose_name_plural = _('restricted items (Restriction categories)')
 
     # Information about restricted item categories that some clients never eat
     #   for allergy or other reasons (ex. Gluten, Nuts, Pork)

--- a/src/meal/tests.py
+++ b/src/meal/tests.py
@@ -1,5 +1,6 @@
 import datetime
 
+from django.contrib.auth.models import User
 from django.test import TestCase
 
 from meal.models import Component, Component_ingredient
@@ -183,3 +184,31 @@ class Restricted_itemTestCase(TestCase):
         name = 'pork'
         restricted_item = Restricted_item.objects.get(name=name)
         self.assertEqual(name, str(restricted_item))
+
+
+class MealAdminTestCase(TestCase):
+
+    fixtures = ['sample_data']
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.admin = User.objects.create_superuser(
+            username='admin@example.com',
+            email='admin@example.com',
+            password='test1234'
+        )
+
+    def setUp(self):
+        self.client.login(username=self.admin.username, password='test1234')
+
+    def test_component_search(self):
+        response = self.client.get('/admin/meal/component/?q=ess')
+        self.assertTrue(b'Diabetic' in response.content)
+
+    def test_ingredient_search(self):
+        response = self.client.get('/admin/meal/ingredient/?q=ann')
+        self.assertTrue(b'Canned' in response.content)
+
+    def test_restricted_item_search(self):
+        response = self.client.get('/admin/meal/restricted_item/?q=ea')
+        self.assertTrue(b'eef' in response.content)


### PR DESCRIPTION
## Fixes #679.

### Changes proposed in this pull request:

* meal/admin.py : inline ingredients under restricted items, sort names alphabetically, list display with group, search in name and search in group to allow filtering.
* meal/models.py : more explicit verbose names for restricted_item and for component.
* delivery/fixtures/sample_data.json : corrected ingredient groups values and restricted_item groups values such that they comply with the allowed choices and therefore will appear in the meal admin.
* meal/locale/fr/LC_MESSAGES/django.po : improved translations.
* meal/tests.py : tests for meal admin search.

### Status

- [X] READY

### How to verify this change
1- Stop webserver
2- Backup your current database
3- Start webserver
4- python manage.py flush
5- python manage.py createsuperuser
6- python manage.py loaddata sample_data
7- login to SousChef with admin rights
8- click on Admin in the left menu
9- click on "Components (Dishes and recipes)" and verify that the names are sorted, that the component groups are all displayed and that search works on names and on groups.
10- click on Home then on "Ingredients" and verify that the names are sorted, that the ingredient groups are all displayed and that search works on names and on groups.
11- click on Home then on "Restricted items (Restriction categories)" and verify that the names are sorted, that the restricted_item groups are all displayed and that search works on names and on groups.
12- in the list of restricted_items, click on "green veggies" and verify that all the Incompatibilitys section shows all the ingredients (Arugula, Bok choy, ... zucchini) that correspond to this restriction category.

### Deployment notes and migration

* In the production database, we should check that in table component, column component_group, the values comply with COMPONENT_GROUP_CHOICES = ('main_dish', 'dessert', 'diabetic', 'fruit_salad', 'green_salad', 'pudding',  'compote', 'sides').
* In the production database, we should check that in table ingredient, column ingredient_group, the values comply with INGREDIENT_GROUP_CHOICES = ('meat', 'dairy', 'fish', 'seafood', 'veggies_and_fruits', 'legumineuse', 'grains', 'fresh_herbs', 'spices', 'dry_and_canned_goods', 'oils_and_sauces').
* In the production database, we should check that in table restricted_item, column restricted_item_group, the values comply with RESTRICTED_ITEM_GROUP_CHOICES = ('meat', 'vegetables', 'seafood', 'seeds and nuts', 'other').
