### PR TITLE
Fixed #687: Add a Cancel button on the kitchen count review step

### DIFF
--- a/src/delivery/locale/en/LC_MESSAGES/django.po
+++ b/src/delivery/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-01-13 20:39+0000\n"
+"POT-Creation-Date: 2017-03-15 15:23-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -310,7 +310,11 @@ msgstr ""
 msgid "Review or change the status of the order."
 msgstr ""
 
-#: delivery/templates/partials/generated_orders.html:51
+#: delivery/templates/partials/generated_orders.html:52
+msgid "Cancel the order."
+msgstr ""
+
+#: delivery/templates/partials/generated_orders.html:53
 msgid "Change the details of the order."
 msgstr ""
 
@@ -452,68 +456,68 @@ msgstr ""
 msgid "Include a bill"
 msgstr ""
 
-#: delivery/tests.py:916
+#: delivery/tests.py:995
 msgid "Main Dish"
 msgstr ""
 
-#: delivery/urls.py:11
+#: delivery/urls.py:13
 msgid "^order/$"
 msgstr ""
 
-#: delivery/urls.py:12
+#: delivery/urls.py:14
 msgid "^meal/$"
 msgstr ""
 
-#: delivery/urls.py:13
+#: delivery/urls.py:15
 msgid "^meal/(?P<id>\\d+)/$"
 msgstr ""
 
-#: delivery/urls.py:14
+#: delivery/urls.py:16
 msgid "^route/$"
 msgstr ""
 
-#: delivery/urls.py:15
+#: delivery/urls.py:17
 msgid "^routes/$"
 msgstr ""
 
-#: delivery/urls.py:16
+#: delivery/urls.py:18
 msgid "^route/(?P<id>\\d+)$"
 msgstr ""
 
-#: delivery/urls.py:18
+#: delivery/urls.py:20
 msgid "^kitchen_count/$"
 msgstr ""
 
-#: delivery/urls.py:19
+#: delivery/urls.py:21
 #, python-brace-format
 msgid "^kitchen_count/(?P<year>\\d{4})/(?P<month>\\d{2})/(?P<day>\\d+)/$"
 msgstr ""
 
-#: delivery/urls.py:21
+#: delivery/urls.py:23
 msgid "^viewDownloadKitchenCount/$"
 msgstr ""
 
-#: delivery/urls.py:23
+#: delivery/urls.py:25
 msgid "^viewMealLabels/$"
 msgstr ""
 
-#: delivery/urls.py:24
+#: delivery/urls.py:26
 msgid "^route_sheet/(?P<id>\\d+)/$"
 msgstr ""
 
-#: delivery/urls.py:26
+#: delivery/urls.py:28
 msgid "^getDailyOrders/$"
 msgstr ""
 
-#: delivery/urls.py:27
+#: delivery/urls.py:29
 msgid "^refresh_orders/$"
 msgstr ""
 
-#: delivery/urls.py:29
+#: delivery/urls.py:31
 msgid "^save_route/$"
 msgstr ""
 
-#: delivery/urls.py:30
+#: delivery/urls.py:32
 msgid "^save_route_vehicle/$"
 msgstr ""
 

--- a/src/delivery/locale/fr/LC_MESSAGES/django.po
+++ b/src/delivery/locale/fr/LC_MESSAGES/django.po
@@ -2,149 +2,184 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-11-22 23:01+0000\n"
+"POT-Creation-Date: 2017-03-15 15:23-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: PascalPriori <pascal.priori@savoirfairelinux.com>, 2016\n"
-"Language-Team: French (https://www.transifex.com/savoirfairelinux/teams/63058/fr/)\n"
+"Language-Team: French (https://www.transifex.com/savoirfairelinux/"
+"teams/63058/fr/)\n"
+"Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: fr\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#: delivery/filters.py:14
+msgid "Search by client name"
+msgstr ""
 
 #: delivery/forms.py:11
 msgid "Today's main dish:"
 msgstr "Plat du jour:"
 
 #: delivery/forms.py:18
-msgid "Select Ingredients:"
+#, fuzzy
+#| msgid "Select Ingredients:"
+msgid "Select main dish ingredients:"
 msgstr "Sélectionner les ingrédients:"
+
+#: delivery/forms.py:26
+#, fuzzy
+#| msgid "Select Ingredients:"
+msgid "Select sides ingredients:"
+msgstr "Sélectionner les ingrédients:"
+
+#: delivery/forms.py:37
+msgid "Please choose some Sides ingredients"
+msgstr ""
 
 #: delivery/models.py:10
 msgid "deliveries"
 msgstr "livraisons"
 
-#: delivery/templates/ingredients.html:5
+#: delivery/templates/ingredients.html:6
 msgid "Pick Ingredients"
 msgstr "Sélectionner les ingrédients"
 
-#: delivery/templates/ingredients.html:12
+#: delivery/templates/ingredients.html:14
 msgid "Pick ingredients"
 msgstr "Sélectionner les ingrédients"
 
-#: delivery/templates/ingredients.html:27
+#: delivery/templates/ingredients.html:29
 msgid "Main dish"
 msgstr "Plat principal"
 
-#: delivery/templates/ingredients.html:70
+#: delivery/templates/ingredients.html:66
 msgid "Restore recipe"
 msgstr "Restaurer la recette"
 
-#: delivery/templates/ingredients.html:76
-#: delivery/templates/kitchen_count.html:82 delivery/templates/routes.html:53
+#: delivery/templates/ingredients.html:82
+#: delivery/templates/kitchen_count.html:102 delivery/templates/routes.html:71
 msgid "Back"
 msgstr "Précédent"
 
-#: delivery/templates/ingredients.html:77
+#: delivery/templates/ingredients.html:84
 msgid "Next: Print Kitchen Count"
 msgstr "Suivant: Imprimer l'inventaire"
 
-#: delivery/templates/kitchen_count.html:5
+#: delivery/templates/kitchen_count.html:6
 msgid "Kitchen Count report"
 msgstr "Inventaire des repas"
 
-#: delivery/templates/kitchen_count.html:12
+#: delivery/templates/kitchen_count.html:14
 msgid "Kitchen Count Report"
 msgstr "Inventaire des repas"
 
-#: delivery/templates/kitchen_count.html:20
-msgid "Print the Report"
-msgstr "Imprimer l'inventaire des repas"
-
-#: delivery/templates/kitchen_count.html:22
-msgid "Download Labels"
-msgstr "Télécharger les étiquettes"
+#: delivery/templates/kitchen_count.html:23
+#, fuzzy
+#| msgid "Kitchen Count report"
+msgid "Download the kitchen count report"
+msgstr "Inventaire des repas"
 
 #: delivery/templates/kitchen_count.html:24
-msgid "No Labels Found"
-msgstr "Aucune étiquette trouvée"
+#: delivery/templates/kitchen_count.html:28
+#: delivery/templates/kitchen_count_steps.html:18
+msgid "Kitchen Count"
+msgstr "Kitchen Count"
+
+#: delivery/templates/kitchen_count.html:27
+#, fuzzy
+#| msgid "Kitchen Count report"
+msgid "No kitchen count report available"
+msgstr "Inventaire des repas"
 
 #: delivery/templates/kitchen_count.html:32
+#, fuzzy
+#| msgid "Download Labels"
+msgid "Download the labels"
+msgstr "Télécharger les étiquettes"
+
+#: delivery/templates/kitchen_count.html:33
+#: delivery/templates/kitchen_count.html:37
+msgid "Labels"
+msgstr ""
+
+#: delivery/templates/kitchen_count.html:36
+msgid "No labels available"
+msgstr ""
+
+#: delivery/templates/kitchen_count.html:46
 msgid "Component"
 msgstr "Composant"
 
-#: delivery/templates/kitchen_count.html:33
-#: delivery/templates/kitchen_count.html:34
+#: delivery/templates/kitchen_count.html:47
+#: delivery/templates/kitchen_count.html:48
 msgid "TOTAL"
 msgstr "TOTAL"
 
-#: delivery/templates/kitchen_count.html:33
-#: delivery/templates/route_sheet.html:22
+#: delivery/templates/kitchen_count.html:47
+#: delivery/templates/route_sheet.html:32
+#: delivery/templates/routes_print.html:33
 msgid "Regular"
 msgstr "Régulier"
 
-#: delivery/templates/kitchen_count.html:34
-#: delivery/templates/route_sheet.html:23
+#: delivery/templates/kitchen_count.html:48
+#: delivery/templates/route_sheet.html:33
+#: delivery/templates/routes_print.html:34
 msgid "Large"
 msgstr "Grand"
 
-#: delivery/templates/kitchen_count.html:35
+#: delivery/templates/kitchen_count.html:49
 msgid "Dish today"
 msgstr "Plat du jour"
 
-#: delivery/templates/kitchen_count.html:36
+#: delivery/templates/kitchen_count.html:50
 msgid "Ingredients today"
 msgstr "Ingrédients du jour"
 
-#: delivery/templates/kitchen_count.html:55
-msgid "Clashing"
-msgstr "En conflit"
+#: delivery/templates/kitchen_count.html:69
+#, fuzzy
+#| msgid "Pick ingredients"
+msgid "Clashing ingredients"
+msgstr "Sélectionner les ingrédients"
 
-#: delivery/templates/kitchen_count.html:55
-#: delivery/templates/kitchen_count_steps.html:12
-msgid "Ingredients"
-msgstr "Ingrédients"
-
-#: delivery/templates/kitchen_count.html:56
-#: delivery/templates/kitchen_count.html:57
-#: delivery/templates/route_sheet.html:43
+#: delivery/templates/kitchen_count.html:70
+#: delivery/templates/kitchen_count.html:71
+#: delivery/templates/route_sheet.html:53
+#: delivery/templates/routes_print.html:55
 msgid "Qty"
 msgstr "Qte"
 
-#: delivery/templates/kitchen_count.html:56
+#: delivery/templates/kitchen_count.html:70
 msgid "Reg"
 msgstr "Rég"
 
-#: delivery/templates/kitchen_count.html:57
+#: delivery/templates/kitchen_count.html:71
 msgid "Lge"
 msgstr "Lrg"
 
-#: delivery/templates/kitchen_count.html:58
-#: delivery/templates/review_orders.html:77
-#: delivery/templates/route_sheet.html:40
+#: delivery/templates/kitchen_count.html:72
+#: delivery/templates/partials/generated_orders.html:12
+#: delivery/templates/route_sheet.html:50
+#: delivery/templates/routes_print.html:52
 msgid "Client"
 msgstr "Client"
 
-#: delivery/templates/kitchen_count.html:59
-msgid "Preparation"
-msgstr "Préparation"
-
-#: delivery/templates/kitchen_count.html:60
+#: delivery/templates/kitchen_count.html:73 delivery/views.py:967
 msgid "Restrictions"
 msgstr "Restrictions"
 
-#: delivery/templates/kitchen_count.html:83
+#: delivery/templates/kitchen_count.html:105
 msgid "Next: Organize Routes"
 msgstr "Suivant: Organiser les itinéraires"
 
 #: delivery/templates/kitchen_count_steps.html:6
-#: delivery/templates/review_orders.html:13
+#: delivery/templates/review_orders.html:15
 msgid "Review Orders"
 msgstr "Réviser les commandes"
 
@@ -152,13 +187,13 @@ msgstr "Réviser les commandes"
 msgid "Review orders for the day."
 msgstr "Réviser les commandes du jour."
 
+#: delivery/templates/kitchen_count_steps.html:12 delivery/views.py:974
+msgid "Ingredients"
+msgstr "Ingrédients"
+
 #: delivery/templates/kitchen_count_steps.html:13
 msgid "Pick ingredients for the day."
 msgstr "Sélectionner les ingrédients du jour."
-
-#: delivery/templates/kitchen_count_steps.html:18
-msgid "Kitchen Count"
-msgstr "Kitchen Count"
 
 #: delivery/templates/kitchen_count_steps.html:19
 msgid "Print the kitchen count."
@@ -172,181 +207,391 @@ msgstr "Routes"
 msgid "Organize delivery routes."
 msgstr "Organiser les routes de livraison."
 
-#: delivery/templates/organize_route.html:6
+#: delivery/templates/organize_route.html:7
 msgid "Organize the delivery route"
 msgstr "Organiser l'itinéraire de livraison"
 
-#: delivery/templates/organize_route.html:19
+#: delivery/templates/organize_route.html:21
+#: delivery/templates/organize_route.html:64
+#: delivery/templates/organize_route.html:75
 msgid "Delivery route"
 msgstr "Route de livraison"
 
-#: delivery/templates/organize_route.html:36 delivery/templates/routes.html:35
+#: delivery/templates/organize_route.html:28
+msgid "Print the map and directions"
+msgstr ""
+
+#: delivery/templates/organize_route.html:29
+msgid "Map and Directions"
+msgstr ""
+
+#: delivery/templates/organize_route.html:50 delivery/templates/routes.html:45
 msgid "Print the route sheet"
 msgstr "Imprimer l'itinéraire de la route."
 
-#: delivery/templates/organize_route.html:37 delivery/templates/routes.html:36
+#: delivery/templates/organize_route.html:51 delivery/templates/routes.html:46
 msgid "Route sheet"
 msgstr "Itinéraire de route"
 
-#: delivery/templates/organize_route.html:39
-#: delivery/templates/route_sheet.html:77
+#: delivery/templates/organize_route.html:53
+#: delivery/templates/route_sheet.html:101
 msgid "View routes list"
 msgstr "Afficher la liste des itinéraires"
 
-#: delivery/templates/organize_route.html:40
-#: delivery/templates/route_sheet.html:78
+#: delivery/templates/organize_route.html:54
+#: delivery/templates/route_sheet.html:102
 msgid "View routes"
 msgstr "Afficher les routes"
 
-#: delivery/templates/review_orders.html:6
-#: delivery/templates/review_orders.html:65
-msgid "Orders"
-msgstr "Commandes"
+#: delivery/templates/organize_route.html:79
+#: delivery/templates/routes_print.html:23
+msgid "Print"
+msgstr ""
 
-#: delivery/templates/review_orders.html:27
-msgid "Orders of the day"
-msgstr "Commandes du jour"
+#: delivery/templates/organize_route.html:100
+#, fuzzy
+#| msgid "Route sheet"
+msgid "Route Sequence"
+msgstr "Itinéraire de route"
 
-#: delivery/templates/review_orders.html:74
+#: delivery/templates/organize_route.html:105
+#, fuzzy
+#| msgid "Client"
+msgid "Client Name"
+msgstr "Client"
+
+#: delivery/templates/organize_route.html:106
+msgid "Address"
+msgstr ""
+
+#: delivery/templates/organize_route.html:124
+#, fuzzy
+#| msgid "Restrictions"
+msgid "Directions"
+msgstr "Restrictions"
+
+#: delivery/templates/partials/generated_orders.html:9
 msgid "Order"
 msgstr "Commande"
 
-#: delivery/templates/review_orders.html:75
-#: delivery/templates/review_orders.html:81
-#: delivery/templates/review_orders.html:84
-#: delivery/templates/review_orders.html:90
-msgid "Order\\"
+#: delivery/templates/partials/generated_orders.html:10
+msgid "A unique identifier for the order."
 msgstr ""
 
-#: delivery/templates/review_orders.html:78
-msgid "Quickly access the client\\"
+#: delivery/templates/partials/generated_orders.html:13
+msgid "Quickly access the client file."
 msgstr ""
 
-#: delivery/templates/review_orders.html:80
+#: delivery/templates/partials/generated_orders.html:15
 msgid "Delivery Date"
 msgstr "Date de livraison"
 
-#: delivery/templates/review_orders.html:83
+#: delivery/templates/partials/generated_orders.html:16
+msgid "The delivery date planned for the order."
+msgstr ""
+
+#: delivery/templates/partials/generated_orders.html:18
 msgid "Route"
 msgstr "Route"
 
-#: delivery/templates/review_orders.html:86
+#: delivery/templates/partials/generated_orders.html:19
+#, fuzzy
+#| msgid "Delivery route"
+msgid "The delivery route."
+msgstr "Route de livraison"
+
+#: delivery/templates/partials/generated_orders.html:21
 msgid "Status"
 msgstr "État"
 
-#: delivery/templates/review_orders.html:87
+#: delivery/templates/partials/generated_orders.html:22
 msgid "Display only Ordered orders."
 msgstr "Affiche seulement les commandes Commandées."
 
-#: delivery/templates/review_orders.html:89
+#: delivery/templates/partials/generated_orders.html:24
 msgid "Amount"
 msgstr "Montant"
 
-#: delivery/templates/review_orders.html:103
-msgid "View Order"
-msgstr "Voir la commande"
+#: delivery/templates/partials/generated_orders.html:25
+msgid "Total amount in $CAD."
+msgstr ""
 
-#: delivery/templates/review_orders.html:111
-msgid "orders today"
-msgstr "commandes aujourd'hui"
+#: delivery/templates/partials/generated_orders.html:41
+msgid ""
+"Please fix geolocalization. Otherwise this client will be excluded in the "
+"next steps."
+msgstr ""
 
-#: delivery/templates/review_orders.html:117
+#: delivery/templates/partials/generated_orders.html:44
+msgid ""
+"Please fix delivery route. Otherwise this client will be excluded in the "
+"next steps."
+msgstr ""
+
+#: delivery/templates/partials/generated_orders.html:50
+msgid "Review or change the status of the order."
+msgstr ""
+
+#: delivery/templates/partials/generated_orders.html:52
+msgid "Cancel the order."
+msgstr ""
+
+#: delivery/templates/partials/generated_orders.html:53
+msgid "Change the details of the order."
+msgstr ""
+
+#: delivery/templates/review_orders.html:7
+msgid "Orders"
+msgstr "Commandes"
+
+#: delivery/templates/review_orders.html:29
+msgid "Orders of the day"
+msgstr "Commandes du jour"
+
+#: delivery/templates/review_orders.html:31
+msgid ""
+"Orders of the day include ongoing and episodic clients. Only Ordered orders "
+"from Active clients are included."
+msgstr ""
+
+#: delivery/templates/review_orders.html:58
+msgid "Generate orders"
+msgstr ""
+
+#: delivery/templates/review_orders.html:62
+#, python-format
+msgid ""
+"\n"
+"                        <span>%(count)s</span>\n"
+"                        &nbsp;today\n"
+"                    "
+msgstr ""
+
+#: delivery/templates/review_orders.html:75
+#, fuzzy
+#| msgid "Review Orders"
+msgid "Review"
+msgstr "Réviser les commandes"
+
+#: delivery/templates/review_orders.html:82
+#, fuzzy
+#| msgid "Client"
+msgid "Client name"
+msgstr "Client"
+
+#: delivery/templates/review_orders.html:92
+msgid "Reset"
+msgstr ""
+
+#: delivery/templates/review_orders.html:93
+msgid "Search"
+msgstr ""
+
+#: delivery/templates/review_orders.html:102
 msgid "OK, I'm ready"
 msgstr "Allons-y!"
 
-#: delivery/templates/route_sheet.html:5
+#: delivery/templates/route_sheet.html:6
 msgid "Delivery Route Sheet"
 msgstr "Itinéraire de livraison"
 
 #: delivery/templates/route_sheet.html:21
+#, fuzzy
+#| msgid "Print the route sheet"
+msgid "Print the route sheet."
+msgstr "Imprimer l'itinéraire de la route."
+
+#: delivery/templates/route_sheet.html:22
+#, fuzzy
+#| msgid "Route sheet"
+msgid "Route Sheet"
+msgstr "Itinéraire de route"
+
+#: delivery/templates/route_sheet.html:31
+#: delivery/templates/routes_print.html:32
 msgid "Dish"
 msgstr "Plat"
 
-#: delivery/templates/route_sheet.html:41
+#: delivery/templates/route_sheet.html:51
+#: delivery/templates/routes_print.html:53
 msgid "Note"
 msgstr "Note"
 
-#: delivery/templates/route_sheet.html:42
+#: delivery/templates/route_sheet.html:52
+#: delivery/templates/routes_print.html:54
 msgid "Item"
 msgstr "Article"
 
-#: delivery/templates/route_sheet.html:53
+#: delivery/templates/route_sheet.html:54
+msgid "Bill"
+msgstr ""
+
+#: delivery/templates/route_sheet.html:64
+#: delivery/templates/routes_print.html:66
 msgid "Apt"
 msgstr "App"
 
-#: delivery/templates/route_sheet.html:74 delivery/templates/routes.html:32
+#: delivery/templates/route_sheet.html:86
+#: delivery/templates/routes_print.html:83
+msgid "Yes"
+msgstr ""
+
+#: delivery/templates/route_sheet.html:88
+#: delivery/templates/routes_print.html:85
+#, fuzzy
+#| msgid "Note"
+msgid "No"
+msgstr "Note"
+
+#: delivery/templates/route_sheet.html:98 delivery/templates/routes.html:42
 msgid "Organize the route"
 msgstr "Organiser l'itinéraire"
 
-#: delivery/templates/route_sheet.html:75 delivery/templates/routes.html:33
+#: delivery/templates/route_sheet.html:99 delivery/templates/routes.html:43
 msgid "Organize"
 msgstr "Organiser"
 
-#: delivery/templates/routes.html:6
+#: delivery/templates/routes.html:7 delivery/templates/routes_print.html:7
+#: delivery/templates/routes_print.html:22
 msgid "Routes Information"
 msgstr "Information de routes"
 
-#: delivery/templates/routes.html:20
+#: delivery/templates/routes.html:22
 msgid "Delivery routes"
 msgstr "Itinéraires de livraisons"
 
-#: delivery/templates/routes.html:43
-msgid "Cycling map"
+#: delivery/templates/routes.html:30
+#, fuzzy
+#| msgid "Print the route sheet"
+msgid "Print the route sheets"
+msgstr "Imprimer l'itinéraire de la route."
+
+#: delivery/templates/routes.html:31
+#, fuzzy
+#| msgid "Route sheet"
+msgid "Route Sheets"
+msgstr "Itinéraire de route"
+
+#: delivery/templates/routes.html:54
+#, fuzzy
+#| msgid "Cycling map"
+msgid "Cycling"
 msgstr "Carte cycliste"
 
-#: delivery/templates/routes.html:44
+#: delivery/templates/routes.html:56
+msgid "Driving"
+msgstr ""
+
+#: delivery/templates/routes.html:58
+msgid "Walking"
+msgstr ""
+
+#: delivery/templates/routes.html:60
 msgid "Number of orders on this route"
 msgstr "Nombre de commande sur l'itinéraire"
 
-#: delivery/urls.py:10
+#: delivery/templates/routes_print.html:56
+msgid "Include a bill"
+msgstr ""
+
+#: delivery/tests.py:995
+#, fuzzy
+#| msgid "Main dish"
+msgid "Main Dish"
+msgstr "Plat principal"
+
+#: delivery/urls.py:13
 msgid "^order/$"
 msgstr "^order/$"
 
-#: delivery/urls.py:11
+#: delivery/urls.py:14
 msgid "^meal/$"
 msgstr "^meal/$"
 
-#: delivery/urls.py:12
+#: delivery/urls.py:15
 msgid "^meal/(?P<id>\\d+)/$"
 msgstr "^meal/(?P<id>\\d+)/$"
 
-#: delivery/urls.py:13
+#: delivery/urls.py:16
 msgid "^route/$"
 msgstr "^route/$"
 
-#: delivery/urls.py:14
+#: delivery/urls.py:17
 msgid "^routes/$"
 msgstr ""
 
-#: delivery/urls.py:15
+#: delivery/urls.py:18
 msgid "^route/(?P<id>\\d+)$"
 msgstr ""
 
-#: delivery/urls.py:17
+#: delivery/urls.py:20
 msgid "^kitchen_count/$"
 msgstr "^kitchen_count/$"
 
-#: delivery/urls.py:18
+#: delivery/urls.py:21
 #, python-brace-format
 msgid "^kitchen_count/(?P<year>\\d{4})/(?P<month>\\d{2})/(?P<day>\\d+)/$"
 msgstr "^kitchen_count/(?P<year>\\d{4})/(?P<month>\\d{2})/(?P<day>\\d+)/$"
 
-#: delivery/urls.py:20
+#: delivery/urls.py:23
+#, fuzzy
+#| msgid "^kitchen_count/$"
+msgid "^viewDownloadKitchenCount/$"
+msgstr "^kitchen_count/$"
+
+#: delivery/urls.py:25
 msgid "^viewMealLabels/$"
 msgstr ""
 
-#: delivery/urls.py:21
+#: delivery/urls.py:26
 msgid "^route_sheet/(?P<id>\\d+)/$"
 msgstr "^route_sheet/(?P<id>\\d+)/$"
 
-#: delivery/urls.py:23
+#: delivery/urls.py:28
 msgid "^getDailyOrders/$"
 msgstr "^getDailyOrders/$"
 
-#: delivery/urls.py:24
+#: delivery/urls.py:29
 msgid "^refresh_orders/$"
 msgstr "^refresh_orders/$"
 
-#: delivery/urls.py:25
+#: delivery/urls.py:31
 msgid "^save_route/$"
 msgstr ""
+
+#: delivery/urls.py:32
+msgid "^save_route_vehicle/$"
+msgstr ""
+
+#: delivery/views.py:962
+msgid "LARGE"
+msgstr ""
+
+#: delivery/views.py:979
+msgid "Preparation"
+msgstr "Préparation"
+
+#: delivery/views.py:991
+msgid "Sides clashes"
+msgstr ""
+
+#: delivery/views.py:1020
+#, fuzzy
+#| msgid "Restrictions"
+msgid "Other restrictions"
+msgstr "Restrictions"
+
+#~ msgid "Print the Report"
+#~ msgstr "Imprimer l'inventaire des repas"
+
+#~ msgid "No Labels Found"
+#~ msgstr "Aucune étiquette trouvée"
+
+#~ msgid "Clashing"
+#~ msgstr "En conflit"
+
+#~ msgid "View Order"
+#~ msgstr "Voir la commande"
+
+#~ msgid "orders today"
+#~ msgstr "commandes aujourd'hui"

--- a/src/delivery/templates/partials/generated_orders.html
+++ b/src/delivery/templates/partials/generated_orders.html
@@ -48,10 +48,17 @@
         <td class="center aligned"><i class="dollar icon"></i>{{order.price}}</td>
         <td>
             <a class="ui basic icon button" title="{% trans 'Review or change the status of the order.' %}"  href="{% url 'order:view' pk=order.id %}"><i class="icon unhide"></i></a>
-            {% if can_edit_data %}<a class="ui basic icon button" title="{% trans 'Change the details of the order.' %}" href="{% url 'order:update' pk=order.id %}"><i class="icon edit"></i></a>{% endif %}
+            {% if can_edit_data %}
+              <a class="ui basic icon button" title="{% trans 'Change the details of the order.' %}" href="{% url 'order:update' pk=order.id %}"><i class="icon edit"></i></a>
+              <a class="ui basic icon order cancel button" title="{% trans 'Cancel the order.' %}" data-url="{% url 'order:update_status' pk=order.id %}"><i class="icon ban"></i></a>
+            {% endif %}
         </td>
       </tr>
       {% endif %}
     {% endfor %}
   </tbody>
 </table>
+
+{% if can_edit_data %}
+  <div class="ui modal status"></div>
+{% endif %}

--- a/src/frontend/js/delivery.js
+++ b/src/frontend/js/delivery.js
@@ -22,6 +22,39 @@ $(function() {
         });
     });
 
+    $('.ui.order.cancel.button').click(function () {
+        var self = this;
+        var modalCtntURL = $(self).attr('data-url');
+        $.get(modalCtntURL, {status:'C'}, function(data, modalCtntURL){
+            $('.ui.modal.status').html(data).modal("setting", {
+                closable: false,
+                // When approving modal, submit form
+                onApprove: function($element, modalCtntURL) {
+                    var data = $('#change-status-form').serializeArray();
+
+                    $.ajax({
+                         type: 'POST',
+                         url: $(self).attr('data-url'),
+                         data: data,
+                         success: function (xhr, ajaxOptions, thrownError) {
+                             if ( $(xhr).find('.errorlist').length > 0 ) {
+                                 $('.ui.modal.status').html(xhr);
+                             } else {
+                                 $('.ui.modal.status').modal("hide");
+                                 location.reload();
+                             }
+                         },
+                     });
+                    return false; // don't hide modal until we have the response
+                },
+                // When denying modal, restore default value for status dropdown
+                onDeny: function($element) {
+                    $('.ui.modal.status').modal("hide");
+                }
+            }).modal('setting', 'autofocus', false).modal("show");
+        });
+    });
+
     $('input[name=include_a_bill]').change(function () {
         var self = this;
         var url = $(self).data('url');

--- a/src/frontend/js/order.js
+++ b/src/frontend/js/order.js
@@ -37,7 +37,7 @@ $(function() {
                     addReasonSelectListener();
                     updateOtherFieldStatus();
                 },
-                // When approvind modal, submit form
+                // When approving modal, submit form
                 onApprove: function($element, modalCtntURL) {
                     var origdata = $('#change-status-form').serializeArray();
                     var origdata_o = {};


### PR DESCRIPTION
## Fixes #687.

### Changes proposed in this pull request:

* Add a Cancel Order button to the orders listed on the Kitchen Count screen, Review Orders step.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Follow Steps to reproduce as noted in #687. There, click the Cancel button. The Change Status modal (same as used on the View Order page) is displayed, allowing the user to enter a comment for their change. If the modal is submitted, the order should be successfully cancelled.

### Deployment notes and migration

- [ ] Migration is needed for this change

### New translatable strings

- [X] If applicable, I have included updated .po files with new strings (see http://goo.gl/kfBO7N)

Please note that there were a lot of extraneous changes to the .po files that do not relate to the one new string I added for this fix (in `src/delivery/locale`). This might be normal but it just looked weird to me ;) If these should not be added in this pull, please let me know and I can revert the commit.

### Additional notes

none
