### PR TITLE
Fixed #686: Make it possible to create orders for all clients

### DIFF
--- a/src/order/forms.py
+++ b/src/order/forms.py
@@ -86,7 +86,7 @@ class CreateOrdersBatchForm(forms.Form):
         required=True,
         label=_('Client'),
         widget=BatchFormClientSelect(attrs={'class': 'ui search dropdown'}),
-        queryset=Client.active.all().select_related(
+        queryset=Client.objects.all().select_related(
             'member'
         ).only(
             'member__firstname',


### PR DESCRIPTION
## Fixes #686  by lingxiaoyang

### Changes proposed in this pull request:

* In batch order creation form, the client select dropdown now displays all clients, regardless of their statuses.

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

1. Set a client from active to pause.
2. Go to batch creation form, verify that the client is one of the dropdown options.
3. Select this client, and create orders for it. Verify the order is well created.

### Deployment notes and migration

none

### New translatable strings

none

### Additional notes

*If applicable, explain the rationale behind your change.*
