### PR TITLE
Fixed #697: Differentiate superimposed stops and remove directions in route map

### DIFF
--- a/src/delivery/templates/organize_route.html
+++ b/src/delivery/templates/organize_route.html
@@ -31,7 +31,7 @@
 </div>
 
 <div class="row">
-  <div class="thirteen wide column" id="route_map"
+  <div class="eleven wide column" id="route_map"
         data-route="{{ route.id }}"
         data-save-url="{% if can_edit_data %}{% url 'delivery:save_route' %}{% endif %}"
         {% comment %} JSON uses double quotes, so use single quotes for this attr {% endcomment %}
@@ -41,7 +41,7 @@
         data-can-save="{{ can_edit_data|yesno:'yes,no' }}">
     {% leaflet_map "main" callback="main_map_init" %}
   </div>
-  <div class="three wide column">
+  <div class="five wide column">
     <div class="controls"></div>
   </div>
 </div>
@@ -96,6 +96,11 @@
       <hr />
 
       <h2>{% trans 'Route Sequence' %}</h2>
+      <br />
+      {% verbatim %}
+      <h4>{{ distance_and_time }}</h4>
+      {% endverbatim %}
+      <br />
       <table style="width: 100%">
         <thead>
           <tr>
@@ -116,19 +121,6 @@
         </tbody>
         {% endverbatim %}
       </table>
-
-      <hr />
-
-      <h2>{% trans 'Directions' %}</h2>
-      {% verbatim %}
-      <h4>{{ distance_and_time }}</h4>
-      {% endverbatim %}
-      <table style="width: 100%" id="directions">
-        {% verbatim %}
-        {{{ directions_table }}}
-        {% endverbatim %}
-      </table>
-      <br/>
     </body>
   </html>
 </script>

--- a/src/frontend/js/custom-leaflet.js
+++ b/src/frontend/js/custom-leaflet.js
@@ -69,10 +69,13 @@ function getRouteWaypoints(routeId) {
              waypoints[i].name = data.waypoints[i].member ;
         }
 
-        //add fisrt waypoint for santropol
+        //add first waypoint for santropol
         var santro = new deliveryPoints(L.latLng(45.516564,  -73.575145));
-        santro.name = "santropol";
+        santro.name = "Santropol Roulant";
         waypoints.splice(0, 0, santro);
+
+        // add return waypoint to go back to santropol
+        waypoints.push(santro);
 
         // Set waypoints on the map
         control.setWaypoints(waypoints);

--- a/src/frontend/js/custom-leaflet.js
+++ b/src/frontend/js/custom-leaflet.js
@@ -231,7 +231,7 @@ function main_map_init (map, options) {
                     });
 
                     var info = "<div class='ui list'>"
-                        +"<div class='item'><i class='user icon'></i> Santro </div>"
+                        +"<div class='item'><i class='food icon'></i> Santropol Roulant </div>"
                         +"</div>"
 
                     marker.bindPopup(info).openPopup();

--- a/src/frontend/js/custom-leaflet.js
+++ b/src/frontend/js/custom-leaflet.js
@@ -238,23 +238,14 @@ function main_map_init (map, options) {
 
                     return marker;
                 }
-                else if (wp.santro) {
-                  return;
-                }
-                else {
-                  var markerIcon;
-
-                  if (wp.options.multipleClients) {
-                    markerIcon = L.AwesomeMarkers.icon({icon: 'star', prefix: 'fa', markerColor: 'blue', iconColor: 'white'})
-                  } else {
-                    markerIcon = L.icon.glyph({
-                      prefix: '',
-                      glyph: String.fromCharCode(65 + i)
-                    });
-                  }
-
+                else if (!wp.santro) {
                   marker = L.marker(wp.latLng, {
-                    icon: markerIcon,
+                    icon: markerIcon = L.icon.glyph({
+                      prefix: '',
+                      glyph: wp.options.multipleClients ?
+                        String.fromCharCode(65 + i) + '*' :
+                        String.fromCharCode(65 + i)
+                    }),
                     draggable: true
                   });
 

--- a/src/frontend/js/custom-leaflet.js
+++ b/src/frontend/js/custom-leaflet.js
@@ -41,8 +41,7 @@ function printMapAndItinerary() {
         map_imgs: map_imgs,
         map_route_svg: $('svg.leaflet-zoom-animated')[0].outerHTML,
         routes: routes,
-        distance_and_time: directions.find('> h3').text(),
-        directions_table: directions.find('> table').html()
+        distance_and_time: directions.find('> h3').text()
     };
 
     var w = window.open('');
@@ -71,10 +70,17 @@ function getRouteWaypoints(routeId) {
 
         //add first waypoint for santropol
         var santro = new deliveryPoints(L.latLng(45.516564,  -73.575145));
+        santro.santro = true;
         santro.name = "Santropol Roulant";
+        santro.options.address = "111 rue Roy Est";
         waypoints.splice(0, 0, santro);
 
         // add return waypoint to go back to santropol
+        var santro = new deliveryPoints(L.latLng(45.516564,  -73.575145));
+        santro.santro = true;
+        santro.hideMarker = true;
+        santro.name = "Santropol Roulant";
+        santro.options.address = "111 rue Roy Est";
         waypoints.push(santro);
 
         // Set waypoints on the map
@@ -186,7 +192,7 @@ function main_map_init (map, options) {
                 var marker;
 
                 // adjust marker according waypoints
-                if (wp.name == "santropol") {
+                if (wp.santro && !wp.hideMarker) {
                     // add awesome marker for santropol
                     marker =  L.marker([45.516564, -73.575145], {
                         draggable: false,
@@ -201,6 +207,9 @@ function main_map_init (map, options) {
                     marker.bindPopup(info).openPopup();
 
                     return marker;
+                }
+                else if (wp.santro) {
+                  return;
                 }
                 else {
                     marker =  L.marker(wp.latLng, {
@@ -244,7 +253,8 @@ function main_map_init (map, options) {
                         {color: 'blue', opacity: 0.25, weight: 3}
                     ]
                 },
-                plan: plan
+                plan: plan,
+                show: false
             });
         },
     });

--- a/src/frontend/scss/base/delivery.scss
+++ b/src/frontend/scss/base/delivery.scss
@@ -1,0 +1,3 @@
+.leaflet-routing-alt {
+  display: none;
+}

--- a/src/frontend/scss/main.scss
+++ b/src/frontend/scss/main.scss
@@ -7,4 +7,5 @@
 @import "base/menu";
 @import "base/global";
 @import "base/map";
+@import "base/delivery";
 @import "base/multidatespicker";


### PR DESCRIPTION
## Fixes #697 by @lamontfr 

### Changes proposed in this pull request:

On both the route planner and printout...

* ...multiple "waypoints" (clients) at the same address show on the map as a special marker with a star in it, indicating that more than one client can be found at the same location.
* ...when an address has multiple clients, the address is only listed once, and the clients' names are comma-separated.
* ...a final waypoint has been added, showing the itinerary for the return trip to Santropol Roulant.
* ...the turn-by-turn directions have been removed.


### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

* Ensure that you have at least two clients in a single route that share a street address and a delivery on the date in question.
* Proceed through the Kitchen Count process until you arrive at the Routes Information screen.
* Browse to the route that has the two clients in it, and click Organize.
* Verify that:
  * ... one map marker with a white star appears above the street address that has two clients
  * ... the waypoint list in the sidebar contains only one entry for said address, and both clients' names show up as comma-separated.
  * ... the turn-by-turn directions do not appear
* Click "Map and Directions" and repeat the aforementioned verifications.

### Deployment notes and migration

- [ ] Migration is needed for this change

### New translatable strings

- [ ] If applicable, I have included updated .po files with new strings (see https://github.com/savoirfairelinux/sous-chef/blob/dev/docs/internationalization.adoc)

### Additional notes

* The mechanism to group map markers (and waypoints) by address is done by comparing the latitude and longitude of the geocoded points for the clients in question. If the latitudes and longitudes are equal to within five decimal points of tolerance, the clients will be considered to live at the same street address.
* Apartment numbers are not listed on the Delivery Route printout, rather only on the Routes Information printout. I did not change this as it was existing behaviour and the issue did not request a change in this regard.