### PR TITLE
Fixed #706: define the behavior of meals_schedule without client option.

### DIFF
--- a/src/member/models.py
+++ b/src/member/models.py
@@ -705,18 +705,26 @@ class Client(models.Model):
     def meals_schedule(self):
         """
         Returns a list of tuple ((weekday, meal default), ...).
+        If client option 'meals_schedule' is not set, simply return
+        everyday's default as None (no delivery).
 
         Intended to be used for Ongoing clients.
         """
         defaults = self.meals_default
         prefs = []
         simple_meals_schedule = self.simple_meals_schedule
-        for day, meal_schedule in defaults:
-            if day not in simple_meals_schedule:
+
+        if simple_meals_schedule is None:
+            for day, _ in defaults:
                 prefs.append((day, None))
-            else:
-                prefs.append((day, meal_schedule))
-        return prefs
+            return prefs
+        else:
+            for day, meal_schedule in defaults:
+                if day not in simple_meals_schedule:
+                    prefs.append((day, None))
+                else:
+                    prefs.append((day, meal_schedule))
+            return prefs
 
     def set_meals_schedule(self, schedule):
         """

--- a/src/member/tests.py
+++ b/src/member/tests.py
@@ -408,7 +408,7 @@ class ClientMealDefaultWeekTestCase(TestCase):
         meals_schedule_option = Option.objects.create(
             name='meals_schedule', option_group='dish'
         )
-        Client_option.objects.create(
+        cls.clientOptionTest = Client_option.objects.create(
             client=cls.clientTest,
             option=meals_schedule_option,
             value=json.dumps(['monday', 'wednesday', 'friday']),
@@ -461,6 +461,21 @@ class ClientMealDefaultWeekTestCase(TestCase):
             'compote': 0
         })
         self.assertEqual(ms['tuesday'], None)  # no delivery scheduled
+        self.assertEqual(ms['wednesday'], None)
+        self.assertEqual(ms['thursday'], None)
+        self.assertEqual(ms['friday'], None)
+        self.assertEqual(ms['saturday'], None)
+        self.assertEqual(ms['sunday'], None)
+
+    def test_client_meals_schedule_without_option(self):
+        """
+        Test when the client option 'meals_schedule' is not set.
+        Refs #706.
+        """
+        self.clientOptionTest.delete()
+        ms = dict(self.clientTest.meals_schedule)
+        self.assertEqual(ms['monday'], None)
+        self.assertEqual(ms['tuesday'], None)
         self.assertEqual(ms['wednesday'], None)
         self.assertEqual(ms['thursday'], None)
         self.assertEqual(ms['friday'], None)


### PR DESCRIPTION
## Fixes #706  by lingxiaoyang

### Changes proposed in this pull request:

* If a client has no option "meals_schedule" and is an ongoing client, consider it as no delivery instead of raising an Python error.
* Unit test

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

1. Find an ongoing client, verify its delivery status on http://localhost:8000/member/view/{ID}/preferences
2. Go to Django admin, find this client, delete its client option "meals_schedule".
3. Refresh the previous page, and you should see "No delivery" on all days, instead of having a server error.

### Deployment notes and migration

none

### New translatable strings

none

### Additional notes

none