### PR TITLE
Fixed #720: Restricted button to remove scheduled status to admin users

### DIFF
--- a/src/member/templates/client/view/status.html
+++ b/src/member/templates/client/view/status.html
@@ -2,6 +2,9 @@
 <!-- Load internationalisation utils-->
 {% load i18n %}
 {% load admin_urls %}
+{% load rules %}
+
+{% has_perm 'sous_chef.edit' request.user as can_edit_data %}
 
 {% block title %}
 
@@ -44,7 +47,7 @@
                 <th>{% trans 'To' %}</th>
                 <th>{% trans 'Reason' %}</th>
                 <th>{% trans 'Operation status' %}</th>
-                {% if user.is_staff %}<th></th>{% endif %}
+                {% if can_edit_data %}<th></th>{% endif %}
             </tr>
         </thead>
         <tbody>
@@ -60,7 +63,7 @@
                 <td>{{ status.get_status_to_display }}</td>
                 <td>{{ status.reason }}</td>
                 <td>{{ status.get_operation_status_display }}</td>
-                {% if user.is_staff %}<td><a href="{% url 'member:delete_status' pk=status.pk %}" class="mini ui red button remove-status">{% trans "Remove" %}</a></td>{% endif %}
+                {% if can_edit_data %}<td><a href="{% url 'member:delete_status' pk=status.pk %}" class="mini ui red button remove-status">{% trans "Remove" %}</a></td>{% endif %}
             </tr>
             {% endfor %}
         {% endif %}
@@ -69,7 +72,7 @@
 </div>
 
 <!-- Modal confirmation -->
-{% if user.is_staff %}
+{% if can_edit_data %}
     <div id="remove-status-confirmation" class="ui modal"></div>
 {% endif %}
 

--- a/src/member/templates/client/view/status.html
+++ b/src/member/templates/client/view/status.html
@@ -44,7 +44,7 @@
                 <th>{% trans 'To' %}</th>
                 <th>{% trans 'Reason' %}</th>
                 <th>{% trans 'Operation status' %}</th>
-                <th></th>
+                {% if user.is_staff %}<th></th>{% endif %}
             </tr>
         </thead>
         <tbody>
@@ -60,7 +60,7 @@
                 <td>{{ status.get_status_to_display }}</td>
                 <td>{{ status.reason }}</td>
                 <td>{{ status.get_operation_status_display }}</td>
-                <td><a href="{% url 'member:delete_status' pk=status.pk %}" class="mini ui red button remove-status">{% trans "Remove" %}</a></td>
+                {% if user.is_staff %}<td><a href="{% url 'member:delete_status' pk=status.pk %}" class="mini ui red button remove-status">{% trans "Remove" %}</a></td>{% endif %}
             </tr>
             {% endfor %}
         {% endif %}
@@ -69,6 +69,8 @@
 </div>
 
 <!-- Modal confirmation -->
-<div id="remove-status-confirmation" class="ui modal"></div>
+{% if user.is_staff %}
+    <div id="remove-status-confirmation" class="ui modal"></div>
+{% endif %}
 
 {% endblock %}

--- a/src/member/tests.py
+++ b/src/member/tests.py
@@ -2251,7 +2251,7 @@ class ClientStatusUpdateAndScheduleCase(TestCase):
             )
         )
 
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, 302)
 
 
 class ClientUpdateTestCase(TestCase):

--- a/src/member/views.py
+++ b/src/member/views.py
@@ -1450,14 +1450,10 @@ class ClientStatusScheduler(
         )
 
 
-class ClientStatusSchedulerDeleteView(LoginRequiredMixin, generic.DeleteView):
+class ClientStatusSchedulerDeleteView(PermissionRequiredMixin, generic.DeleteView):
     model = ClientScheduledStatus
+    permission_required = 'sous_chef.edit'
     template_name = "client/view/delete_status_confirmation.html"
-
-    def post(self, request, *args, **kwargs):
-        if not request.user.is_staff:
-            return HttpResponseBadRequest()
-        return super().post(request, *args, **kwargs)
 
     def get_success_url(self):
         return reverse(

--- a/src/member/views.py
+++ b/src/member/views.py
@@ -1450,7 +1450,8 @@ class ClientStatusScheduler(
         )
 
 
-class ClientStatusSchedulerDeleteView(PermissionRequiredMixin, generic.DeleteView):
+class ClientStatusSchedulerDeleteView(
+        PermissionRequiredMixin, generic.DeleteView):
     model = ClientScheduledStatus
     permission_required = 'sous_chef.edit'
     template_name = "client/view/delete_status_confirmation.html"

--- a/src/member/views.py
+++ b/src/member/views.py
@@ -6,6 +6,7 @@ from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.contrib.auth.decorators import login_required
+from django.http import HttpResponseBadRequest
 from django.urls import reverse_lazy, reverse
 from django.db.models import Q
 from django.db.transaction import atomic
@@ -1449,9 +1450,14 @@ class ClientStatusScheduler(
         )
 
 
-class ClientStatusSchedulerDeleteView(generic.DeleteView):
+class ClientStatusSchedulerDeleteView(LoginRequiredMixin, generic.DeleteView):
     model = ClientScheduledStatus
     template_name = "client/view/delete_status_confirmation.html"
+
+    def post(self, request, *args, **kwargs):
+        if not request.user.is_staff:
+            return HttpResponseBadRequest()
+        return super().post(request, *args, **kwargs)
 
     def get_success_url(self):
         return reverse(


### PR DESCRIPTION
## Fixes # by aaboffill

### Changes proposed in this pull request:

* Added restriction to show the button to remove `Scheduled Status Change` to the admin users only.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

* Login into the system with a not admin user.
* Go to a client's view.
* Schedule a status change by using the status button, at the top-right.
* Go to the list and the button to remove `Schedule Status Change` won't be displayed.
