### PR TITLE
Fixed #723: Restricted birthday date field to only past dates

### DIFF
--- a/src/frontend/js/billing.js
+++ b/src/frontend/js/billing.js
@@ -12,11 +12,7 @@ $(function() {
         type: 'month',
         formatter: {
             date: function (date, settings) {
-                if (!date) return '';
-                var month = date.getMonth() + 1;
-                var year = date.getFullYear();
-                if (month < 10) month = '0' + month;
-                return year + '-' + month ;
+                return date ? dateFormat(date, 'yyyy-mm') : '';
             }
         }
     });

--- a/src/frontend/js/global.js
+++ b/src/frontend/js/global.js
@@ -24,13 +24,7 @@ $(function() {
         type: 'date',
         formatter: {
             date: function (date, settings) {
-                if (!date) return '';
-                var day = date.getDate();
-                var month = date.getMonth() + 1;
-                var year = date.getFullYear();
-                if (month < 10) month = '0' + month;
-                if (day < 10) day = '0' + day;
-                return year + '-' + month + '-' + day;
+                return date ? dateFormat(date, 'yyyy-mm-dd') : '';
             }
         }
     });

--- a/src/frontend/js/member.js
+++ b/src/frontend/js/member.js
@@ -2,10 +2,10 @@ $(function() {
 
     // Javascript of the member application.
     // **************************************
+    var today = new Date();
 
     $('.ui.dropdown.member.status > .menu > .item').click(function () {
         var value = $(this).data('value');
-        var today = new Date();
         var modalCtntURL = $('.ui.dropdown.status').attr('data-url');
         $.get(modalCtntURL, {status:value}, function(data, modalCtntURL){
             $('.ui.modal.status').html(data).modal("setting", {
@@ -18,19 +18,10 @@ $(function() {
                     $('#rangestart').calendar({
                         type: 'date',
                         on: 'click',
-                        minDate: new Date(
-                            today.getFullYear(),
-                            today.getMonth(),
-                            today.getDate()),
+                        minDate: today,
                         formatter: {
                             date: function (date, settings) {
-                                if (!date) return '';
-                                var day = date.getDate();
-                                var month = date.getMonth() + 1;
-                                var year = date.getFullYear();
-                                if (month < 10) month = '0' + month;
-                                if (day < 10) day = '0' + day;
-                                return year + '-' + month + '-' + day;
+                                return date ? dateFormat(date, 'yyyy-mm-dd') : '';
                             }
                         },
                         endCalendar: $('#rangeend'),
@@ -39,13 +30,7 @@ $(function() {
                         type: 'date',
                         formatter: {
                             date: function (date, settings) {
-                                if (!date) return '';
-                                var day = date.getDate();
-                                var month = date.getMonth() + 1;
-                                var year = date.getFullYear();
-                                if (month < 10) month = '0' + month;
-                                if (day < 10) day = '0' + day;
-                                return year + '-' + month + '-' + day;
+                                return date ? dateFormat(date, 'yyyy-mm-dd') : '';
                             }
                         },
                         startCalendar: $('#rangestart'),
@@ -76,6 +61,16 @@ $(function() {
                 }
             }).modal('setting', 'autofocus', false).modal("show");
         });
+    });
+
+    $('#wizard_form_birthdate').calendar({
+        type: 'date',
+        maxDate: today,
+        formatter: {
+            date: function (date, settings) {
+                return date ? dateFormat(date, 'yyyy-mm-dd') : '';
+            }
+        },
     });
 
     var removeStatusConfirmationModal = $('#remove-status-confirmation');

--- a/tools/gulp/gulpfile.js
+++ b/tools/gulp/gulpfile.js
@@ -32,6 +32,7 @@ const sources = {
         'node_modules/jquery-tablesort/jquery-tablesort.js',
         'node_modules/jquery.formset/src/jquery.formset.js',
         'node_modules/semantic-ui-calendar/dist/calendar.js',
+        'node_modules/dateformat/lib/dateformat.js',
       ],
       site: [
         `${SRC_JS}/global.js`,


### PR DESCRIPTION
## Fixes # by aaboffill

### Changes proposed in this pull request:

* Added restriction to avoid select dates in the future for the birthday date field. 
* Added `node_modules/dateformat/lib/dateformat.js` to the vendors, in order to make more simple and clear the format date `JavaScript` code.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

* Go to the Client menu.
* Select add new Client
* We can check that we cannot select future dates in the birthday field.
