### PR TITLE
Fixed: npm dependency on dateformat

### DIFF
--- a/tools/gulp/package.json
+++ b/tools/gulp/package.json
@@ -32,6 +32,7 @@
     "leaflet.awesome-markers": "^2.0.4",
     "leaflet.icon.glyph": "^0.2.0",
     "semantic-ui-calendar": "0.0.7",
-    "sortablejs": "^1.5.1"
+    "sortablejs": "^1.5.1",
+    "dateformat": "^2.0.0"
   }
 }


### PR DESCRIPTION
#724 introduced a new JS package but it was not included in package.json. Thus it is not pulled during `npm install` and is not included when running `gulp`. This PR provides the hotfix.