### PR TITLE
Update dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-django>=1.10,<1.10.99
+django>=1.11,<1.11.99
 mysqlclient>=1.3,<1.3.99
 gunicorn>=19.7,<19.7.99
 factory_boy>=2.8,<2.8.99
@@ -6,7 +6,7 @@ django-formtools>=2.0,<2.0.99
 django-filter>=1.0,<1.0.99
 django-annoying>=0.10,<0.10.99
 reportlab>=3.4,<3.4.99
-django-leaflet>=0.21,<0.21.99
+django-leaflet>=0.22,<0.22.99
 django-extra-views>=0.9,<0.9.99
 transifex-client>=0.12,<0.12.99
 django-template-i18n-lint>=1.2,<1.2.99

--- a/tools/gulp/package.json
+++ b/tools/gulp/package.json
@@ -31,7 +31,7 @@
     "leaflet-routing-machine": "^3.2.5",
     "leaflet.awesome-markers": "^2.0.4",
     "leaflet.icon.glyph": "^0.2.0",
-    "semantic-ui-calendar": "0.0.7",
+    "semantic-ui-calendar": "0.0.8",
     "sortablejs": "^1.5.1",
     "dateformat": "^2.0.0"
   }


### PR DESCRIPTION
## Fixes "Dependencies out of date" by erozqba

### Changes proposed in this pull request:

* Django upgrade from 1.10.7	to 1.11
* django-leaflet upgrade from 0.21.0 to 0.22.0
* semantic-ui-calendar upgrade from 0.0.7 to 0.0.8
* Remove one line from travis.yml that make the test run twice. 

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

You will need to stop, destroy and recreate images, containers, volumes, and networks.

### Deployment notes and migration

- [ ] Migration is needed for this change

### New translatable strings

- [ ] If applicable, I have included updated .po files with new strings (see https://github.com/savoirfairelinux/sous-chef/blob/dev/docs/internationalization.adoc)

### Additional notes

*If applicable, explain the rationale behind your change.*
