### PR TITLE
Fixed #734: don't generate orders when it's out of client's delivery schedule

### DIFF
--- a/src/datamigration/management/commands/importclients.py
+++ b/src/datamigration/management/commands/importclients.py
@@ -99,4 +99,4 @@ class Command(BaseCommand):
                 client.member.save()
 
                 # Add Client option meals_schedule
-                # client.set_meals_schedule([])
+                # client.set_simple_meals_schedule([])

--- a/src/datamigration/management/commands/importmeals.py
+++ b/src/datamigration/management/commands/importmeals.py
@@ -91,7 +91,7 @@ class Command(BaseCommand):
                             prefs['diabetic_' + row[day] + '_quantity'] = \
                                 int(row[11 + (delivery_day * 10) + 4])
 
-                    client.set_meals_schedule(meals_schedule)
+                    client.set_simple_meals_schedule(meals_schedule)
                     client.meal_default_week = prefs
                     client.save()
 

--- a/src/member/models.py
+++ b/src/member/models.py
@@ -748,32 +748,17 @@ class Client(models.Model):
                     prefs.append((day, meal_schedule))
             return prefs
 
-    def set_meals_schedule(self, schedule):
+    def set_simple_meals_schedule(self, schedule):
         """
-        [LXYANG] Rename to set_simple_meals_schedule.
         Set the delivery days for the client.
         @param schedule
             A python list of days.
         """
-        id = None
-        try:
-            option, created = Option.objects.get_or_create(
-                name='meals_schedule')
-            meals_schedule_option = Client_option.objects.get(
-                client=self, option=option
-            )
-            id = meals_schedule_option.id
-        except Client_option.DoesNotExist:
-            pass
-
-        option, created = Client_option.objects.update_or_create(
-            id=id,
-            defaults={
-                'client': self,
-                'option': option,
-                'value': json.dumps(schedule),
-            }
-        )
+        meal_schedule_option, _ = Option.objects.get_or_create(
+            name='meals_schedule')
+        client_option, _ = Client_option.objects.update_or_create(
+            client=self, option=meal_schedule_option,
+            defaults={'value': json.dumps(schedule)})
 
 
 class ClientScheduledStatus(models.Model):

--- a/src/member/views.py
+++ b/src/member/views.py
@@ -455,7 +455,7 @@ class ClientWizard(
         preferences = self.form_dict['dietary_restriction'].cleaned_data
 
         # Save meals schedule as a Client option
-        client.set_meals_schedule(
+        client.set_simple_meals_schedule(
             preferences.get('meals_schedule')
         )
 
@@ -1213,7 +1213,7 @@ class ClientUpdateDietaryRestriction(ClientUpdateInformation):
         Save the basic information step data.
         """
         # Save meals schedule as a Client option
-        client.set_meals_schedule(
+        client.set_simple_meals_schedule(
             form['meals_schedule']
         )
 


### PR DESCRIPTION
## Fixes #734  by lingxiaoyang

### Changes proposed in this pull request:

* Two unit tests for midnight order generation and kitchen count refresh order, respectively.
* `Client.set_meals_schedule()` is renamed as `Client.set_simple_meals_schedule()` with code optimised.
* Fixes `Order.auto_create_orders()`: use `Client.meals_schedule` instead of `Client.meals_default`.

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

See #734 

### Deployment notes and migration

none

### New translatable strings

none

### Additional notes

none
