### PR TITLE
Fixed #737: install GDAL library as required by Django 1.11 and dj-leaflet

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update
 RUN apt-get install curl gettext -y
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash -
 RUN apt-get install nodejs build-essential -y
+RUN apt-get install binutils libproj-dev gdal-bin -y
 RUN pip3 install -r requirements.txt
 RUN npm install gulp -g
 ADD . /code/


### PR DESCRIPTION
## Fixes #737 by lingxiaoyang

### Changes proposed in this pull request:

* Add required packages for GIS packages for Django GIS that is used by django-leaflet, according to [Django doc](https://docs.djangoproject.com/en/1.11/ref/contrib/gis/install/geolibs/).

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

```
docker-compose build
docker-compose up
```

There should be no more errors.

### Deployment notes and migration

none

### New translatable strings

none

### Additional notes

none
