### PR TITLE
Add Code Climate configuration.

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,23 @@
+engines:
+  eslint:
+    enabled: false
+  pep8:
+    enabled: true
+  fixme:
+    enabled: true
+  radon:
+    enabled: true
+  duplication:
+    enabled: true
+    config:
+      languages:
+      - javascript:
+      - python:
+ratings:
+   paths:
+   - "src/**/*.py"
+   # - src/**/*.js
+exclude_paths:
+- "**/tests.py"
+- "docs/**/*"
+- "*.csv"


### PR DESCRIPTION
### Changes proposed in this pull request:

* Add a configuration file for Code Climate checks.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### Additional notes

Code Climate (https://codeclimate.com/) is a tool for checking the quality of code using a variety of metrics. Rather than just giving a single pass/fail score if the app's tests pass, or giving a percentage number for code coverage, Code Climate also assesses a project's code complexity in general, including duplication of code and style checks. A GPA-like score is then given after each build, and detailed information can be obtained for each file and code block.

I would encourage reviewers to clone this configuration and get started with using Code Climate in their own forks, to check to see if this is a worthy tool to integrate deeper into the project. It could potentially replace Coveralls, integrate checks into Github pull requests, and much more.