### PR TITLE
Display environment and version below the menu

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,9 @@ services:
       - backend
 
   web:
+    environment:
+      - SOUSCHEF_ENVIRONMENT_NAME=DEV
+      - SOUSCHEF_VERSION=v1.0-beta
     restart: always
     build: .
     volumes:

--- a/src/sous_chef/context_processors.py
+++ b/src/sous_chef/context_processors.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from django.conf import settings
 from member.models import Client, Route
 from order.models import Order, ORDER_STATUS_ORDERED
 from note.models import Note, NoteFilter
@@ -26,7 +27,9 @@ def total(request):
         'CLIENT_FILTER_DEFAULT_STATUS': Client.ACTIVE,
         'ORDER_FILTER_DEFAULT_STATUS': ORDER_STATUS_ORDERED,
         'ORDER_FILTER_DEFAULT_DATE': datetime.datetime.now(),
-        'NOTE_FILTER_DEFAULT_IS_READ': NoteFilter.NOTE_STATUS_UNREAD
+        'NOTE_FILTER_DEFAULT_IS_READ': NoteFilter.NOTE_STATUS_UNREAD,
+        'SC_ENVIRONMENT_NAME': settings.SOUSCHEF_ENVIRONMENT_NAME,
+        'SC_VERSION': settings.SOUSCHEF_VERSION,
     }
 
     return COMMON_CONTEXT

--- a/src/sous_chef/settings.py
+++ b/src/sous_chef/settings.py
@@ -207,3 +207,7 @@ AVATAR_PROVIDERS = (
     'avatar.providers.GravatarAvatarProvider',
     'avatar.providers.DefaultAvatarProvider',
 )
+
+# Displayable information
+SOUSCHEF_VERSION = os.environ.get('SOUSCHEF_VERSION') or ''
+SOUSCHEF_ENVIRONMENT_NAME = os.environ.get('SOUSCHEF_ENVIRONMENT_NAME') or ''

--- a/src/sous_chef/templates/system/menu.html
+++ b/src/sous_chef/templates/system/menu.html
@@ -50,4 +50,5 @@
     <a class="item" href="{% url 'billing:list' %}"><i class="dollar icon"></i>{% trans 'Billing' %}</a>
     {% if request.user.is_superuser %}<a class="item" href="{% url 'admin:index' %}"><i class="settings icon"></i>{% trans 'Admin' %}</a>{% endif %}
     <a href="{% url 'page:logout' %}" class="item"><i class="sign out icon"></i>{% trans 'Logout' %}</a>
+    <p style="color:aqua;"> {{ SC_ENVIRONMENT_NAME }} {{ SC_VERSION }}</p>
 </div>


### PR DESCRIPTION
## Fixes #743.

### Changes proposed in this pull request:

* `docker-compose.yml` : defined environment variables : `souschef_environment_name` (ex. DEV, TEST, PROD), `souschef_version` (ex. v1.0).
* `src/sous_chef/settings.py` : read environment variables into settings constants.
* `src/sous_chef/context_processors.py` : add environment name and version to template context.
* `src/sous_chef/templates/system/menu.html` : display environment name and version at bottom of menu.

### Status

- [X] READY

### How to verify this change

* Restart webserver using command `$ sudo docker-compose up`
* browse to `http://localhost:8000/`
* Notice in the bottom left corner (below the menu) the blue text : DEV v1.0-beta.

### Deployment notes

- When installing Souschef in Production or in Test, the `docker-compose.yml` should be edited to show `SOUSCHEF_ENVIRONMENT_NAME=PROD` or `SOUSCHEF_ENVIRONMENT_NAME=TEST` respectively; also the "tag" of the installed release should be updated in the `yml` file such that `SOUSCHEF_VERSION=tag`.