### PR TITLE
Use nodejs 8.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /code
 ADD requirements.txt /code/
 RUN apt-get update
 RUN apt-get install curl gettext -y
-RUN curl -sL https://deb.nodesource.com/setup_6.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
 RUN apt-get install nodejs build-essential -y
 RUN apt-get install binutils libproj-dev gdal-bin -y
 RUN pip3 install -r requirements.txt


### PR DESCRIPTION
## Fixes #756 

which is that gulp breaks due to half-broken dependencies which seem to have forgotten how to work under old node versions now.

### Changes proposed in this pull request:

* Switch nodejs to the 8.x series (the latest) over the 6.x series

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

*On a fresh checkout* (do something like "git clone https://github.com/kousu/sous-chef && mv sous-chef sous-chef-npm-patch && cd sous-chef-npm-patch" because `docker-compose` uses the name of the folder its in to name its containers), follow INSTALL.md before applying the patch, note that the `gulp` step fails, and then follow it after.

### Deployment notes and migration

- [ ] Migration is needed for this change

### Additional notes

See #756.