### PR TITLE
Kitchen count dish ingredients - show when they change

### DIFF
--- a/src/delivery/forms.py
+++ b/src/delivery/forms.py
@@ -18,7 +18,7 @@ class DishIngredientsForm(forms.Form):
         label=_('Select main dish ingredients:'),
         queryset=Ingredient.objects.order_by(Lower('name')).all(),
         widget=forms.SelectMultiple(
-            attrs={'class': 'ui fluid search dropdown'}),
+            attrs={'class': 'ui fluid search dropdown mainingredients'}),
         required=False,
     )
 
@@ -26,7 +26,7 @@ class DishIngredientsForm(forms.Form):
         label=_('Select sides ingredients:'),
         queryset=Ingredient.objects.order_by(Lower('name')).all(),
         widget=forms.SelectMultiple(
-            attrs={'class': 'ui fluid search dropdown'}),
+            attrs={'class': 'ui fluid search dropdown sidesingredients'}),
         required=False,
     )
 

--- a/src/delivery/locale/fr/LC_MESSAGES/django.po
+++ b/src/delivery/locale/fr/LC_MESSAGES/django.po
@@ -219,6 +219,10 @@ msgstr "Précédent"
 msgid "Next: Print Kitchen Count"
 msgstr "Suivant: Imprimer l'inventaire"
 
+#: delivery/templates/ingredients.html
+msgid "Confirm all ingredients"
+msgstr "Confirmer tous les ingrédients"
+
 #: delivery/templates/kitchen_count.html
 msgid "Kitchen Count report"
 msgstr "Inventaire des repas"
@@ -256,7 +260,7 @@ msgstr ""
 
 #: delivery/templates/kitchen_count.html
 msgid "No labels available"
-msgstr ""
+msgstr "Étiquettes non disponibles"
 
 #: delivery/templates/kitchen_count.html
 msgid "Component"
@@ -265,6 +269,10 @@ msgstr "Composant"
 #: delivery/templates/kitchen_count.html
 msgid "TOTAL"
 msgstr "TOTAL"
+
+#: delivery/templates/kitchen_count.html
+msgid "Please check main dish and confirm all ingredients before proceeding to kitchen count"
+msgstr "SVP vérifier le plat principal et confirmer tous les ingrédients avant de procéder à l'inventaire des repas"
 
 #: delivery/templates/kitchen_count.html delivery/templates/route_sheet.html
 #: delivery/templates/routes_print.html

--- a/src/delivery/templates/ingredients.html
+++ b/src/delivery/templates/ingredients.html
@@ -62,8 +62,8 @@
                 {{ form.ingredients }}
             </div>
             {% if can_edit_data %}
-            <div class="ui field">
-                <input class="ui button" type="submit" value="{% trans "Restore recipe" %}" name="_restore" />
+            <div class="ui row">
+                <input class="ui red button restorerecipe {% if not recipe_changed %}disabled{% endif %}" type="submit" value="{% trans "Restore recipe" %}" name="_restore" />
             </div>
             {% endif %}
         </div>
@@ -76,13 +76,13 @@
         </div>
 
         {% if can_edit_data %}
-        <div class="ten wide column">
-            <div class="ui row">
-                <a class="ui labeled icon big button" href="{% url 'delivery:order' %}">
-                    <i class="chevron left icon"></i>{% trans "Back" %}
-                </a>
-                <input class="ui big yellow button" type="submit" value="{% trans "Next: Print Kitchen Count" %}" name="_next" </>
-            </div>
+        <div class="actions">
+          <a class="ui labeled icon big button" href="{% url 'delivery:order' %}">
+            <i class="chevron left icon"></i>{% trans "Back" %}
+          </a>
+          <input class="ui big green button confirmingredients {% if not ingredients_changed %}disabled{% endif %}" type="submit" value="{% trans "Confirm all ingredients" %}" name="_update" />
+          <a class="ui big yellow button nextkitchencount {% if ingredients_changed %}disabled{% endif %}" href="{% url 'delivery:kitchen_count' %}"> {% trans "Next: Print Kitchen Count" %}
+          </a>
         </div>
         {% endif %}
     </div>

--- a/src/delivery/templates/ingredients.html
+++ b/src/delivery/templates/ingredients.html
@@ -80,8 +80,9 @@
           <a class="ui labeled icon big button" href="{% url 'delivery:order' %}">
             <i class="chevron left icon"></i>{% trans "Back" %}
           </a>
-          <input class="ui big green button confirmingredients {% if not ingredients_changed %}disabled{% endif %}" type="submit" value="{% trans "Confirm all ingredients" %}" name="_update" />
-          <a class="ui big yellow button nextkitchencount {% if ingredients_changed %}disabled{% endif %}" href="{% url 'delivery:kitchen_count' %}"> {% trans "Next: Print Kitchen Count" %}
+          <input class="ui big yellow button confirmingredients {% if not ingredients_changed %}disabled{% endif %}" type="submit" value="{% trans "Confirm all ingredients" %}" name="_update" />
+          <a class="ui labeled icon yellow big button nextkitchencount {% if ingredients_changed %}disabled{% endif %}" href="{% url 'delivery:kitchen_count' %}">
+            <i class="chevron right icon"></i>{% trans "Next: Print Kitchen Count" %}
           </a>
         </div>
         {% endif %}

--- a/src/frontend/js/delivery.js
+++ b/src/frontend/js/delivery.js
@@ -7,6 +7,17 @@ $(function() {
         window.location.replace($url+value);
     });
 
+    $('.ui.dropdown.mainingredients.selection').dropdown('setting', 'onChange', function(value, text, $selectedItem) {
+        $('.button.confirmingredients').removeClass('disabled');
+        $('.button.nextkitchencount').addClass('disabled');
+        $('.button.restorerecipe').removeClass('disabled');
+    });
+
+    $('.ui.dropdown.sidesingredients.selection').dropdown('setting', 'onChange', function(value, text, $selectedItem) {
+        $('.button.confirmingredients').removeClass('disabled');
+        $('.button.nextkitchencount').addClass('disabled');
+    });
+
     $('.button.orders').click(function(){
         $('.button.orders i').addClass('loading');
         $.ajax({


### PR DESCRIPTION
## Fixes #747.

### Changes proposed in this pull request:
* delivery/forms.py : add class to uniquely identify dropdowns in frontend logic.
* delivery/templates/ingredients.html : add `update ingredients` button and logic to enable / disable buttons.
* delivery/views.py : add logic to detect main dish ingredients changes VS recipe, clear all day's ingredients when changing dish, separate update ingredients and next step logic, kitchen count step verifies prerequisites.
* frontend/js/delivery.js : add logic to enable / disable button when UI dropdowns are modified. 

### Status
- [X] READY

### How to verify this change
- Click on Kitchen count
- Generate orders for the day
- Click I'm ready to go to step 2 ingredients
- Select a different main dish
- The Restore button is disabled
- The Confirm all ingredients button is enabled
- The Next button is disabled
- Add two sides ingredients
- Click Update all ingredients
- The Next button is enabled : click it to go to step 3
- Verify Kitchen count main dish and its ingredients
- -----
- Go back to step 2 Ingredients
- Add main dish ingredients(s)
- The Restore button is enabled
- The Confirm all ingredients button is enabled
- The Next button is disabled
- Click Update all ingredients
- The Confirm all ingredients button is disabled
- The Next button is enabled : click it to go to step 3
- Verify Kitchen count main dish and its ingredients
- -----
- Go back to step 2 Ingredients
- The Restore button is enabled
- Click Restore
- The Restore button is disabled
- The Confirm all ingredients button is enabled
- The Next button is disabled
- Click Update all ingredients
- The Confirm all ingredients button is disabled
- The Next button is enabled : click it to go to step 3
- Verify Kitchen count main dish and its ingredients
- -----
- Go back to step 2 Ingredients
- The Confirm all ingredients button is disabled
- Change side dish ingredient(s)
- The Confirm all ingredients button is enabled
- The Next button is disabled
- Click Update all ingredients
- The Confirm all ingredients button is disabled
- The Next button is enabled : click it to go to step 3
- Verify Kitchen count main dish and its ingredients

### New translatable strings

- [X] If applicable, I have included updated .po files with new strings
