### PR TITLE
Only active, paused, pending clients in routes view

### DIFF
--- a/src/member/locale/fr/LC_MESSAGES/django.po
+++ b/src/member/locale/fr/LC_MESSAGES/django.po
@@ -904,8 +904,20 @@ msgid "Last update"
 msgstr "Dernière modification"
 
 #: member/templates/client/list.html
+msgid "Is the client address geolocalized ?"
+msgstr "Est-ce que l'adresse du client est géolocalisée ?"
+
+#: member/templates/client/list.html
+msgid "Yes"
+msgstr "Oui"
+
+#: member/templates/client/list.html
+msgid "No"
+msgstr "Non"
+
+#: member/templates/client/list.html
 msgid "Last modification of the file."
-msgstr ""
+msgstr "Dernière modification du dossier."
 
 #: member/templates/client/list.html
 msgid "of"

--- a/src/member/templates/client/list.html
+++ b/src/member/templates/client/list.html
@@ -102,6 +102,9 @@
             <th class="">{% trans 'Route' %}
                 <i class="help-text question grey icon link" data-content="{% trans 'The delivery route for the client.' %}"></i>
             </th>
+            <th class="">{% trans 'Geolocalized' %}
+                <i class="help-text question grey icon link" data-content="{% trans 'Is the client address geolocalized ?' %}"></i>
+            </th>
             <th class="">{% trans 'Last update' %}
                 <i class="help-text question grey icon link" data-content="{% trans 'Last modification of the file.' %}"></i>
             </th>
@@ -114,6 +117,7 @@
             <td>{{ obj.get_status_display }}</td>
             <td>{{ obj.get_delivery_type_display }}</td>
             <td>{{ obj.route }}</td>
+            <td>{% if obj.is_geolocalized %} {% trans 'Yes' %} {% else %} {% trans 'No' %} {% endif %}</td>
             <td>{{ obj.member.updated_at|date:"Y/m/d H:h:m"  }}</td>
         </tr>
         {% endfor %}

--- a/src/member/tests.py
+++ b/src/member/tests.py
@@ -1,4 +1,5 @@
 import json
+import random
 
 from datetime import date, timedelta
 from decimal import Decimal
@@ -3607,6 +3608,11 @@ class RouteDetailViewTestCase(SousChefTestMixin, TestCase):
             10,
             route=route
         )
+        for client in clients_on_route:
+            client.status = \
+                [Client.PAUSED, Client.ACTIVE, Client.PENDING][
+                    random.randint(0, 2)]
+            client.save()
         clients_organised = (
             clients_on_route[1], clients_on_route[3],
             clients_on_route[5], clients_on_route[7],
@@ -3732,6 +3738,11 @@ class RouteGetOptimisedSequenceViewTestCase(SousChefTestMixin, TestCase):
         clients = ClientFactory.create_batch(
             10,
             route=route)
+        for client in clients:
+            client.status = \
+                [Client.PAUSED, Client.ACTIVE, Client.PENDING][
+                    random.randint(0, 2)]
+            client.save()
 
         self.force_login()
         url = reverse(


### PR DESCRIPTION
## Fixes #771.

### Changes proposed in this pull request:
* member/templates/client/list.html : in client list view, added column to show if client address is geolocalized. This is useful because a single non geolocalized client in a route breaks the display of all clients on the map.
* member/views.py : added filters to count and show only active, paused, or pending clients in the routes list and route detail view.

### Status
- [X] READY

### How to verify this change
- open the client list : http://localhost:8000/member/list/?status=A&display=list
- in the Status dropdown, clear all statuses and click Search
- depending on the data, the list should show some inactive clients (Stop, Deceased ) with "Geolocalized" = No.
- -----
- open the routes list : http://localhost:8000/member/routes/
- for a given route, the number of clients should be less than the quantity in the client list above
- click on the "eye" for a route http://localhost:8000/member/route/6/
- the clients should show on the map
- the status column should contain only "active, paused, or pending".

### New translatable strings
- [X] If applicable, I have included updated .po files with new strings
