### PR TITLE
Update npm dependecies to avoid the warnings 

### DIFF
--- a/tools/gulp/package.json
+++ b/tools/gulp/package.json
@@ -10,7 +10,7 @@
   "private": true,
   "devDependencies": {
     "gulp": "^3.9.1",
-    "gulp-autoprefixer": "^3.1.0",
+    "gulp-autoprefixer": "^4.0.0",
     "gulp-bytediff": "^1.0.0",
     "gulp-cache": "^0.4.0",
     "gulp-clean-css": "^3.0.4",
@@ -20,7 +20,7 @@
     "gulp-jsvalidate": "^3.0.0",
     "gulp-rename": "^1.2.2",
     "gulp-sass": "^3.1.0",
-    "gulp-uglify": "^2.1.2",
+    "gulp-uglify": "^3.0.0",
     "gulp-watch": "^4.3.5"
   },
   "dependencies": {


### PR DESCRIPTION
Update npm dependencies to avoid the warnings  related with minimatch a…nd graceful-fs

Ref: issue #777

## Fixes # by erozqba

### Changes proposed in this pull request:

* Fix warnings of minimatch npm dependency 
* Fix warnings of graceful-fs npm dependency
* ...

### Status

- [ ] READY
- [ ] HOLD
- [X] WIP (Work-In-Progress)

### How to verify this change

1. Remove the node_modules folder: `rm -rf tools/gulp/node_modules`
2. Install npm dependencies and generate assets: `docker-compose exec web sh -c "cd tools/gulp && npm install --unsafe-perm && gulp"`


### Deployment notes and migration

- [ ] Migration is needed for this change

### New translatable strings

- [ ] If applicable, I have included updated .po files with new strings (see https://github.com/savoirfairelinux/sous-chef/blob/dev/docs/internationalization.adoc)

### Additional notes

*If applicable, explain the rationale behind your change.*
