### PR TITLE
Fixed #743: display git information.

### DIFF
--- a/src/sous_chef/context_processors.py
+++ b/src/sous_chef/context_processors.py
@@ -30,6 +30,8 @@ def total(request):
         'NOTE_FILTER_DEFAULT_IS_READ': NoteFilter.NOTE_STATUS_UNREAD,
         'SC_ENVIRONMENT_NAME': settings.SOUSCHEF_ENVIRONMENT_NAME,
         'SC_VERSION': settings.SOUSCHEF_VERSION,
+        'GIT_HEAD': settings.GIT_HEAD,
+        'GIT_TAG': settings.GIT_TAG,
     }
 
     return COMMON_CONTEXT

--- a/src/sous_chef/settings.py
+++ b/src/sous_chef/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/1.9/ref/settings/
 """
 
 import os
+import subprocess
 from django.urls import reverse_lazy
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
@@ -222,3 +223,10 @@ AVATAR_PROVIDERS = (
 # Displayable information
 SOUSCHEF_VERSION = os.environ.get('SOUSCHEF_VERSION') or ''
 SOUSCHEF_ENVIRONMENT_NAME = os.environ.get('SOUSCHEF_ENVIRONMENT_NAME') or ''
+
+try:
+    GIT_HEAD = subprocess.check_output(['git', 'rev-parse', 'HEAD'])
+    GIT_TAG = subprocess.check_output(['git', 'describe', '--tags'])
+except Exception as e:
+    GIT_HEAD = None
+    GIT_TAG = None

--- a/src/sous_chef/templates/system/menu.html
+++ b/src/sous_chef/templates/system/menu.html
@@ -50,5 +50,13 @@
     <a class="item" href="{% url 'billing:list' %}"><i class="dollar icon"></i>{% trans 'Billing' %}</a>
     {% if request.user.is_superuser %}<a class="item" href="{% url 'admin:index' %}"><i class="settings icon"></i>{% trans 'Admin' %}</a>{% endif %}
     <a href="{% url 'page:logout' %}" class="item"><i class="sign out icon"></i>{% trans 'Logout' %}</a>
+    <br />
     <p style="color:aqua;"> {{ SC_ENVIRONMENT_NAME }} {{ SC_VERSION }}</p>
+    {% if GIT_HEAD %}
+    <p style="color:aqua;">Git HEAD: {{ GIT_HEAD|slice:":7" }}</p>
+    {% endif %}
+
+    {% if GIT_TAG %}
+    <p style="color:aqua;">Git tag: {{ GIT_TAG }}</p>
+    {% endif %}
 </div>


### PR DESCRIPTION
## Fixes #743 by lingxiaoyang

### Changes proposed in this pull request:

* Display git HEAD and tag information in sidebar, if they exist:
![image](https://user-images.githubusercontent.com/8630726/28292113-b0668350-6b1b-11e7-9408-4a10e821a8e3.png)


### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

N/A

### Deployment notes and migration

N/A

### New translatable strings

N/A

### Additional notes

*If applicable, explain the rationale behind your change.*
