### PR TITLE
Fix collect static warnings.

### DIFF
--- a/src/member/templates/client/create/form.html
+++ b/src/member/templates/client/create/form.html
@@ -39,7 +39,9 @@
     </h1>
 </div>
 
-<div class="six wide column">
+<div class="ui stackable relaxed grid container">
+
+    <div class="six wide column">
     <div class="ui vertical steps">
       {% trans 'basic_information' as i18n_basic_information %}
       {% trans 'address_information' as i18n_address_information %}
@@ -55,7 +57,7 @@
     </div>
  </div>
 
-<div class="ten wide column form-steps">
+    <div class="ten wide column form-steps">
     <form action="" method="post" class="ui form error">{% csrf_token %}
         {% if wizard.form.errors %}
         <div class="ui error message">
@@ -85,6 +87,8 @@
         {% endif %}
 
     </form>
+</div>
+
 </div>
 {% endblock %}
 

--- a/src/member/templates/client/update/base.html
+++ b/src/member/templates/client/update/base.html
@@ -31,7 +31,9 @@
     </h1>
 </div>
 
-<div class="six wide column">
+<div class="ui stackable relaxed grid container">
+
+    <div class="six wide column">
     <div class="ui vertical steps">
         {% include 'client/update/step.html' with url='member_update_basic_information' step='basic_information' icon='male' name=_('Personal') description=_('First name, last name, ...') %}
         {% include 'client/update/step.html' with url='member_update_address_information' step='address_information' icon='home' name=_('Address') description=_('Street number, city, ...') %}
@@ -41,7 +43,7 @@
     </div>
  </div>
 
-<div class="ten wide column form-steps">
+    <div class="ten wide column form-steps">
 
     <form action="" method="post" class="ui form error">{% csrf_token %}
         {% if form.errors %}
@@ -63,6 +65,8 @@
 
 
     </form>
+</div>
+
 </div>
 {% endblock %}
 

--- a/src/sous_chef/settings.py
+++ b/src/sous_chef/settings.py
@@ -206,7 +206,7 @@ FORMAT_MODULE_PATH = (
 STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 
 STATICFILES_DIRS = (
-    BASE_DIR + '/sous_chef/static/',
+    BASE_DIR + '/sous_chef/assets/',
 )
 STATIC_URL = '/static/'
 

--- a/tools/gulp/gulpfile.js
+++ b/tools/gulp/gulpfile.js
@@ -103,10 +103,10 @@ const sources = {
 
 // - Destination path folders
 const destinations = {
-  css: '../../src/sous_chef/static/css',
-  js: '../../src/sous_chef/static/js',
-  img: '../../src/sous_chef/static/images',
-  fonts: '../../src/sous_chef/static/fonts'
+  css: '../../src/sous_chef/assets/css',
+  js: '../../src/sous_chef/assets/js',
+  img: '../../src/sous_chef/assets/images',
+  fonts: '../../src/sous_chef/assets/fonts'
 };
 
 // Tasks


### PR DESCRIPTION



## Fixes #782 by erozqba

### Changes proposed in this pull request:

* Rename the destination folder for the static assets generated by gulp inside
sous_chef app,  the static files finders will look inside each app for an
static folder and the first files found will be used. This is causing that the
last compiled files are ignored by the static files command when running
the project using the production settings.
https://docs.djangoproject.com/en/1.11/ref/settings/#std:setting-STATICFILES_FINDERS
* Fix grid in the user edit and create page.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

* git clone https://github.com/savoirfairelinux/sous-chef/ sous-chef-prodtest
* cd sous-chef-prodtest
* git checkout -b erozqba-issue_782_styles_prod_settings dev
* git pull https://github.com/erozqba/sous-chef.git issue_782_styles_prod_settings
* docker-compose -f docker-compose.yml -f docker-compose.prod.yml up
* docker-compose exec web bash
* python src/manage.py migrate
* python src/manage.py createsuperuser
* Then logging in the website

### Deployment notes and migration

- [ ] Migration is needed for this change

### New translatable strings

- [ ] If applicable, I have included updated .po files with new strings (see https://github.com/savoirfairelinux/sous-chef/blob/dev/docs/internationalization.adoc)

### Additional notes

*If applicable, explain the rationale behind your change.*
