### PR TITLE
Use nginx container only with in prod settings.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,7 +102,7 @@ tools/gulp
 tools/mariadb
 
 # Ignore generated assets.
-src/sous_chef/static
+src/sous_chef/assets
 
 # Ignore generated pdf files.
 src/*.pdf

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -4,3 +4,17 @@ services:
     environment:
       - SOUSCHEF_ENVIRONMENT_NAME=PROD
       - SOUSCHEF_DJANGO_ALLOWED_HOSTS=souschef.santropolroulant.org
+
+  nginx:
+    restart: always
+    build: tools/nginx
+    command: /bin/bash -c "nginx"
+    ports:
+      - "127.0.0.1:8080:80"
+    volumes:
+      - souschef_static:/code/src/static
+    depends_on:
+      - web
+    networks:
+      - frontend
+      - backend

--- a/docker-compose.travis.yml
+++ b/docker-compose.travis.yml
@@ -7,3 +7,17 @@ services:
       - TRAVIS=$TRAVIS
       - TRAVIS_JOB_ID=$TRAVIS_JOB_ID
       - TRAVIS_BRANCH=$TRAVIS_BRANCH
+
+  nginx:
+    restart: always
+    build: tools/nginx
+    command: /bin/bash -c "nginx"
+    ports:
+      - "127.0.0.1:8080:80"
+    volumes:
+      - souschef_static:/code/src/static
+    depends_on:
+      - web
+    networks:
+      - frontend
+      - backend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,20 +22,6 @@ services:
     networks:
       - backend
 
-  nginx:
-    restart: always
-    build: tools/nginx
-    command: /bin/bash -c "nginx"
-    ports:
-      - "80:80"
-    volumes:
-      - souschef_static:/code/src/static
-    depends_on:
-      - web
-    networks:
-      - frontend
-      - backend
-
 volumes:
   souschef_data:
   souschef_static:


### PR DESCRIPTION
## Fixes  by erozqba

### Changes proposed in this pull request:

* Use nginx container only with in prod settings, because we don't really need for development.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

* docker-compose down
* docker-compose up -d
* docker-compose ps 

The last command should only show two containers running, web and mariadb.

### Deployment notes and migration

- [ ] Migration is needed for this change

### New translatable strings

- [ ] If applicable, I have included updated .po files with new strings (see https://github.com/savoirfairelinux/sous-chef/blob/dev/docs/internationalization.adoc)

### Additional notes

*If applicable, explain the rationale behind your change.*
