### PR TITLE
Add extension in the phone number format error message

### DIFF
--- a/src/member/formsfield.py
+++ b/src/member/formsfield.py
@@ -1,6 +1,7 @@
 import re
 from django import forms
 from django.utils.encoding import smart_text
+from django.utils.translation import ugettext_lazy as _
 from localflavor.ca.forms import (
     CAPhoneNumberField, CAPostalCodeField
 )
@@ -14,6 +15,11 @@ class CAPhoneNumberExtField(CAPhoneNumberField):
     phone_digits_with_ext = re.compile(
             r'^(?:1-?)?(\d{3})[-\.]?(\d{3})[-\.]?(\d{4})#?(\d*)$'
         )
+
+    default_error_messages = {
+        'invalid':
+        _('Phone numbers must be in XXX-XXX-XXXX # XXXXX format.'),
+    }
 
     def clean(self, value):
         try:

--- a/src/member/locale/fr/LC_MESSAGES/django.po
+++ b/src/member/locale/fr/LC_MESSAGES/django.po
@@ -310,6 +310,10 @@ msgstr "Le statut a été changé"
 msgid "The end date of this status change has been scheduled."
 msgstr ""
 
+#: member/formsfield.py
+msgid "Phone numbers must be in XXX-XXX-XXXX # XXXXX format."
+msgstr "Le format du numéro de téléphone doit être XXX-XXX-XXXX # XXXXX."
+
 #: member/models.py
 msgid "Female"
 msgstr "Femme"


### PR DESCRIPTION
## Fixes #787

The phone number format with extensions accepted by the application is XXX-XXX-XXXX # XXXXX but the error message was misleading because it said that phone numbers must be in format XXX-XXX-XXXX.

### Changes proposed in this pull request:
* src/member/formsfield.py : override django.contrib.localflavors CAPhoneNumberField default error message.
* src/member/locale/fr/LC_MESSAGES/django.po : added message and its french translation.

### Status
- [X] READY

### How to verify this change
- Client / Choose client / Client Relationships / Edit / Create new member / type work phone number with wrong format (i.e. 514-876-9876 ext 1234) / Save : should see the error message that shows the required format.

### New translatable strings
- [X] If applicable, I have included updated .po files with new strings (see https://github.com/savoirfairelinux/sous-chef/blob/dev/docs/internationalization.adoc)
