### PR TITLE
Allow blank mid and rid for member

### DIFF
--- a/src/member/models.py
+++ b/src/member/models.py
@@ -96,10 +96,12 @@ class Member(models.Model):
         verbose_name_plural = _('members')
 
     mid = models.IntegerField(
+        blank=True,
         null=True
     )
 
     rid = models.IntegerField(
+        blank=True,
         null=True
     )
 


### PR DESCRIPTION
## Fixes #796.

### Changes proposed in this pull request:
* src/member/models.py : allow blank values

### Status

- [X] READY

### How to verify this change
- Admin / Members / select a member X / check that Mid or Rid is blank / enter some text in work information / Save / see message "The member "X" was changed successfully."
